### PR TITLE
Booter and Loader improvements

### DIFF
--- a/src/components/implementation/cbuf_c/Makefile
+++ b/src/components/implementation/cbuf_c/Makefile
@@ -1,4 +1,4 @@
 INTERFACES=cbuf_c
-DEPENDENCIES=mem_mgr_large printc sched mem_pool lock
+DEPENDENCIES=mem_mgr_large printc sched mem_pool lock cinfo valloc
 
 include ../Makefile.subdir

--- a/src/components/implementation/cbuf_c/naive/cbuf.c
+++ b/src/components/implementation/cbuf_c/naive/cbuf.c
@@ -29,8 +29,6 @@
 #include <cbuf_c.h>
 #include <cvect.h>
 
-#define DEFAULT_TARGET_ALLOC MAX_NUM_MEM 
-
 COS_MAP_CREATE_STATIC(cb_ids);
 
 #define CBUF_OBJ_SZ_SHIFT 6
@@ -705,36 +703,6 @@ cos_init(void *d)
 
 	tmems_allocated = 0;
 
-	// Map all of the spds we can into this component
-	for (i = 0 ; i < MAX_NUM_SPDS ; i++) {
-		spdid_t spdid = i;
-
-		void *hp;
-		hp = valloc_alloc(cos_spd_id(), cos_spd_id(), 1);
-		spdid = cinfo_get_spdid(i);
-		if (!spdid) break;
-
-		if(cinfo_map(cos_spd_id(), (vaddr_t)hp, spdid)){
-			DOUT("Could not map cinfo page for %d\n", spdid);
-			BUG();
-		}
-		spd_tmem_info_list[spdid].ci.spd_cinfo_page = hp;
-
-		spd_tmem_info_list[spdid].ci.meta = NULL; 
-		spd_tmem_info_list[spdid].managed = 1;
-
-		spd_tmem_info_list[spdid].relinquish_mark = 0; 
-    
-		tmems_target += DEFAULT_TARGET_ALLOC;
-		spd_tmem_info_list[spdid].num_allocated = 0;
-		spd_tmem_info_list[spdid].num_desired = DEFAULT_TARGET_ALLOC;
-		spd_tmem_info_list[spdid].num_blocked_thds = 0;
-		spd_tmem_info_list[spdid].num_waiting_thds = 0;
-		spd_tmem_info_list[spdid].num_glb_blocked = 0;
-		spd_tmem_info_list[spdid].ss_counter = 0;
-		spd_tmem_info_list[spdid].ss_max = MAX_NUM_MEM;
-		empty_comps++;
-	}
 	over_quota_total = 0;
 	over_quota_limit = MAX_NUM_MEM;
 

--- a/src/components/implementation/no_interface/boot/boot_deps.h
+++ b/src/components/implementation/no_interface/boot/boot_deps.h
@@ -29,6 +29,21 @@
 COS_VECT_CREATE_STATIC(spd_info_addresses);
 
 int
+cinfo_add(spdid_t spdid, spdid_t target, struct cos_component_information *ci)
+{
+	if (cos_vect_lookup(&spd_info_addresses, target)) return -1;
+	cos_vect_add_id(&spd_info_addresses, (void*)round_to_page(ci), target);
+	return 0;
+}
+
+void*
+cinfo_alloc_page(spdid_t spdid)
+{
+	void *p = cos_get_vas_page();
+	return p;
+}
+
+int
 cinfo_map(spdid_t spdid, vaddr_t map_addr, spdid_t target)
 {
 	vaddr_t cinfo_addr;
@@ -43,22 +58,18 @@ cinfo_map(spdid_t spdid, vaddr_t map_addr, spdid_t target)
 	return 0;
 }
 
-spdid_t
-cinfo_get_spdid(int iter)
+int
+cinfo_spdid(spdid_t spdid)
 {
-	if (iter > MAX_NUM_SPDS) return 0;
-	if (hs[iter] == NULL) return 0;
-
-	return hs[iter]->id;
+	return cos_spd_id();
 }
 
 static int boot_spd_set_symbs(struct cobj_header *h, spdid_t spdid, struct cos_component_information *ci);
 static void
 comp_info_record(struct cobj_header *h, spdid_t spdid, struct cos_component_information *ci)
 {
-	if (!cos_vect_lookup(&spd_info_addresses, spdid)) {
+	if (!cinfo_add(cos_spd_id(), spdid, ci)) {
 		boot_spd_set_symbs(h, spdid, ci);
-		cos_vect_add_id(&spd_info_addresses, (void*)round_to_page(ci), spdid);
 	}
 }
 

--- a/src/components/implementation/no_interface/cbboot/Makefile
+++ b/src/components/implementation/no_interface/cbboot/Makefile
@@ -1,0 +1,10 @@
+C_OBJS=booter.o
+ASM_OBJS=
+COMPONENT=cbboot.o
+INTERFACES=failure_notif cgraph
+DEPENDENCIES=sched printc mem_mgr cinfo
+IF_LIB=
+ADDITIONAL_LIBS=-lcobj_format
+
+include ../../Makefile.subsubdir
+MANDITORY_LIB=simple_stklib.o

--- a/src/components/implementation/no_interface/cbboot/boot_deps.h
+++ b/src/components/implementation/no_interface/cbboot/boot_deps.h
@@ -1,0 +1,45 @@
+#include <print.h>
+#undef assert
+#define assert(node) do { if (unlikely(!(node))) { debug_print("assert error in @ "); *((int *)0) = 0;} } while(0)
+
+#include <mem_mgr.h>
+#include <sched.h>
+#include <cos_alloc.h>
+#include <cobj_format.h>
+
+/* 
+ * Abstraction layer around 1) synchronization, 2) scheduling and
+ * thread creation, and 3) memory operations.  
+ */
+
+/* synchronization... */
+#define LOCK()   if (sched_component_take(cos_spd_id())) BUG();
+#define UNLOCK() if (sched_component_release(cos_spd_id())) BUG();
+
+/* scheduling/thread operations... */
+#define __sched_create_thread_default sched_create_thread_default
+
+/* memory operations... */
+#define __local_mman_get_page   mman_get_page
+#define __local_mman_alias_page mman_alias_page
+
+#include <cinfo.h>
+#include <cos_vect.h>
+
+static int boot_spd_set_symbs(struct cobj_header *h, spdid_t spdid, struct cos_component_information *ci);
+static void
+comp_info_record(struct cobj_header *h, spdid_t spdid, struct cos_component_information *ci)
+{
+	vaddr_t cinfo_addr = (vaddr_t)cinfo_alloc_page(cos_spd_id());
+	if (cinfo_addr != __local_mman_alias_page(cos_spd_id(), (vaddr_t)round_to_page(ci), cinfo_spdid(cos_spd_id()), cinfo_addr, MAPPING_RW)) BUG();
+	if (!cinfo_add(cos_spd_id(), spdid, cinfo_addr)) {
+		boot_spd_set_symbs(h, spdid, ci);
+	}
+}
+
+static void
+boot_deps_init(void) { return; }
+
+static void
+boot_deps_run(void) { return; }
+

--- a/src/components/implementation/no_interface/cbboot/booter.c
+++ b/src/components/implementation/no_interface/cbboot/booter.c
@@ -1,0 +1,1 @@
+../boot/booter.c

--- a/src/components/implementation/no_interface/cinfo_test/citest.c
+++ b/src/components/implementation/no_interface/cinfo_test/citest.c
@@ -11,15 +11,15 @@ void cos_init(void)
 
 	for (i = 0 ; i < MAX_NUM_SPDS ; i++) {
 		struct cos_component_information *ci;
-		spdid_t spdid;
+		spdid_t spdid = (spdid_t)i;
 
 		cos_set_heap_ptr((void*)(((unsigned long)hp)+PAGE_SIZE));
-		spdid = cinfo_get_spdid(i);
-		if (!spdid) break;
+		//spdid = cinfo_get_spdid(i);
+		//if (!spdid) break;
 
 		if (cinfo_map(cos_spd_id(), (vaddr_t)hp, spdid)) {
 			printc("Could not map cinfo page for %d.\n", spdid);
-			return;
+			continue;
 		}
 		ci = hp;
 		printc("mapped -- id: %ld, hp:%x, sp:%x\n", 

--- a/src/components/implementation/no_interface/tmem_policy/Makefile
+++ b/src/components/implementation/no_interface/tmem_policy/Makefile
@@ -2,7 +2,7 @@ C_OBJS=tmem_policy.o
 ASM_OBJS=
 COMPONENT=tp.o
 INTERFACES=
-DEPENDENCIES=periodic_wake sched printc stkmgr cbuf_c timed_blk valloc mem_mgr_large mem_pool exe_cbuf_synth_hier
+DEPENDENCIES=periodic_wake sched printc stkmgr cbuf_c timed_blk valloc mem_mgr_large mem_pool exe_cbuf_synth_hier cinfo
 IF_LIB=
 
 include ../../Makefile.subsubdir

--- a/src/components/implementation/stkmgr/Makefile
+++ b/src/components/implementation/stkmgr/Makefile
@@ -1,4 +1,4 @@
 INTERFACES=stkmgr
-DEPENDENCIES=mem_mgr_large printc sched mem_pool lock
+DEPENDENCIES=cinfo mem_mgr_large printc sched mem_pool lock valloc
 
 include ../Makefile.subdir

--- a/src/components/implementation/stkmgr/tmem.c
+++ b/src/components/implementation/stkmgr/tmem.c
@@ -27,7 +27,11 @@ get_spd_info(spdid_t spdid)
 
 	assert(spdid < MAX_NUM_SPDS);
 	sti = &spd_tmem_info_list[spdid];
-	
+	if (!SPD_IS_MANAGED(sti)) {
+		if (manage_spd(spdid)) return NULL;
+	}
+	assert(SPD_IS_MANAGED(sti));
+
 	return sti;
 }
 

--- a/src/components/interface/cinfo/cinfo.h
+++ b/src/components/interface/cinfo/cinfo.h
@@ -1,8 +1,10 @@
 #ifndef   	CINFO_H
 #define   	CINFO_H
 
+int cinfo_add(spdid_t spdid, spdid_t target, struct cos_component_information *ci);
+void* cinfo_alloc_page(spdid_t spdid);
 int cinfo_map(spdid_t spdid, vaddr_t map_addr, spdid_t target);
-spdid_t cinfo_get_spdid(int iter);
+int cinfo_spdid(spdid_t spdid);
 
 /* vaddr_t cinfo_map_peek(spdid_t spdid); */
 

--- a/src/components/interface/cinfo/stubs/s_stub.S
+++ b/src/components/interface/cinfo/stubs/s_stub.S
@@ -9,5 +9,7 @@
 
 .text	
 
+cos_asm_server_stub_spdid(cinfo_add)
+cos_asm_server_stub_spdid(cinfo_alloc_page)
 cos_asm_server_stub_spdid(cinfo_map)
-cos_asm_server_stub(cinfo_get_spdid)
+cos_asm_server_stub_spdid(cinfo_spdid)

--- a/src/platform/linux/link_load/cos_loader.c
+++ b/src/platform/linux/link_load/cos_loader.c
@@ -974,8 +974,8 @@ static struct service_symbs *alloc_service_symbs(char *obj, int boot_layer)
 		obj = cpy;
 		off = 0;
 	}
-	printl(PRINT_DEBUG, "Processed object %s (%s%s)\n", obj, t.sched ? "scheduler " : "", 
-	       t.composite_loaded ? "booted" : "");
+	printl(PRINT_DEBUG, "Processed object %s (%s booted by layer %d)\n", obj, t.sched ? "scheduler " : "",
+	       t.composite_loaded);
 	str = malloc(sizeof(struct service_symbs));
 	if (!str || initialize_service_symbs(str)) {
 		return NULL;
@@ -2446,6 +2446,7 @@ make_spd_boot(struct service_symbs *boot, struct service_symbs *all, int layer)
 	new_h       = malloc(h->size + all_obj_sz);
 	assert(new_h);
 	memcpy(new_h, h, h->size);
+	printl(PRINT_DEBUG, "booter realloc %p -> %p with size %d\n", h, new_h, h->size)
 
 	/* Initialize the new section */
 	{
@@ -2465,6 +2466,7 @@ make_spd_boot(struct service_symbs *boot, struct service_symbs *all, int layer)
 
 	ci = (void *)cobj_vaddr_get(new_h, (u32_t)get_symb_address(&boot->exported, COMP_INFO));
 	assert(ci);
+	printl(PRINT_DEBUG, "booter cos_comp_info @ %p\n", ci);
 	ci->cos_poly[0] = ADDR2VADDR(new_sect_start);
 
 	/* copy the cobjs */

--- a/src/platform/linux/util/unit_cbboot_cbuf.sh
+++ b/src/platform/linux/util/unit_cbboot_cbuf.sh
@@ -1,0 +1,31 @@
+#!/bin/sh
+
+./cos_loader \
+"c0.o, ;llboot.o, ;*fprr.o, ;mm.o, ;print.o, ;boot.o, ;\
+\
+!l.o,a1;!mpool.o,a3;!te.o,a3;!sm.o,a4;!e.o,a4;!buf.o,a5;!bufp.o, ;!va.o,a2;!vm.o,a1;!cbboot.o,a6;!tp.o,a7;!ucbuf1.o,a10;!ucbuf2.o, ;!ucbufp.o,a9;!stat.o,a25:\
+\
+c0.o-llboot.o;\
+fprr.o-print.o|[parent_]mm.o|[faulthndlr_]llboot.o;\
+mm.o-[parent_]llboot.o|print.o;\
+boot.o-print.o|fprr.o|mm.o|llboot.o;\
+l.o-fprr.o|mm.o|print.o;\
+te.o-sm.o|print.o|fprr.o|mm.o|va.o;\
+e.o-sm.o|fprr.o|print.o|mm.o|l.o|va.o;\
+stat.o-sm.o|te.o|fprr.o|l.o|print.o|e.o;\
+sm.o-print.o|fprr.o|mm.o|boot.o|va.o|l.o|mpool.o;\
+buf.o-boot.o|sm.o|fprr.o|print.o|l.o|mm.o|va.o|mpool.o;\
+bufp.o-sm.o|fprr.o|print.o|l.o|mm.o|va.o|mpool.o|buf.o;\
+mpool.o-print.o|fprr.o|mm.o|boot.o|va.o|l.o;\
+cbboot.o-print.o|fprr.o|mm.o|boot.o;\
+tp.o-sm.o|buf.o|print.o|te.o|fprr.o|mm.o|va.o|mpool.o;\
+vm.o-fprr.o|print.o|mm.o|l.o|boot.o;\
+va.o-fprr.o|print.o|mm.o|l.o|boot.o|vm.o;\
+ucbuf1.o-fprr.o|sm.o|ucbuf2.o|ucbufp.o|print.o|mm.o|va.o|buf.o|bufp.o|l.o;\
+ucbuf2.o-sm.o|print.o|mm.o|va.o|bufp.o|buf.o|l.o;\
+ucbufp.o-fprr.o|sm.o|print.o|mm.o|va.o|bufp.o|buf.o|l.o\
+" ./gen_client_stub
+
+#mpd.o-sm.o|cg.o|fprr.o|print.o|te.o|mm.o|va.o;\
+#!mpd.o,a5;
+#[print_]trans.o


### PR DESCRIPTION
Fixes the cinfo interface to be less reliant on boot's internal state, refactors cos_loader to allow for more than 2 layers of component booting, and adds a new booter component in cbboot that is loaded by boot. A booter component is identified by cos_loader for any component containing the substring 'boot' in its name.

Adds a test unit_cbboot_cbuf.sh that uses cbboot to boot some of the unit_cbuf.sh test components. Both unit_cbuf.sh and unit_cbboot_cbuf.sh ran successfully.

cbboot is functionally equivalent to boot for the time being, but will eventually replace page-based memory allocations (mman) with cbufp-based memory for booted components.