### PR TITLE
Rewrite cinfo interface

### DIFF
--- a/src/components/implementation/cbuf_mgr/default/Makefile
+++ b/src/components/implementation/cbuf_mgr/default/Makefile
@@ -2,7 +2,7 @@ C_OBJS=cbuf_mgr.o
 ASM_OBJS=
 COMPONENT=cbuf.o
 INTERFACES=cbuf_mgr stkmgr
-DEPENDENCIES=sched printc lock mem_mgr_large valloc cinfo
+DEPENDENCIES=sched printc lock mem_mgr_large valloc
 
 include ../../Makefile.subsubdir
 MANDITORY_LIB=simple_stklib.o

--- a/src/components/implementation/no_interface/boot/boot_deps.h
+++ b/src/components/implementation/no_interface/boot/boot_deps.h
@@ -29,54 +29,29 @@
 COS_VECT_CREATE_STATIC(spd_info_addresses);
 
 int
-cinfo_add(spdid_t spdid, spdid_t target, struct cos_component_information *ci)
+cinfo_add_heap_pointer(spdid_t spdid, spdid_t target, void *heap_pointer)
 {
 	if (cos_vect_lookup(&spd_info_addresses, target)) return -1;
-	cos_vect_add_id(&spd_info_addresses, (void*)round_to_page(ci), target);
+	cos_vect_add_id(&spd_info_addresses, heap_pointer, target);
 	return 0;
 }
 
 void*
-cinfo_alloc_page(spdid_t spdid)
+cinfo_get_heap_pointer(spdid_t spdid, spdid_t target)
 {
-	void *p = cos_get_vas_page();
-	return p;
-}
-
-int
-cinfo_map(spdid_t spdid, vaddr_t map_addr, spdid_t target)
-{
-	vaddr_t cinfo_addr;
-
-	cinfo_addr = (vaddr_t)cos_vect_lookup(&spd_info_addresses, target);
-	if (0 == cinfo_addr) return -1;
-	if (map_addr != 
-	    (__local_mman_alias_page(cos_spd_id(), cinfo_addr, spdid, map_addr, MAPPING_RW))) {
-		return -1;
-	}
-
-	return 0;
-}
-
-int
-cinfo_spdid(spdid_t spdid)
-{
-	return cos_spd_id();
-}
-
-static int boot_spd_set_symbs(struct cobj_header *h, spdid_t spdid, struct cos_component_information *ci);
-static void
-comp_info_record(struct cobj_header *h, spdid_t spdid, struct cos_component_information *ci)
-{
-	if (!cinfo_add(cos_spd_id(), spdid, ci)) {
-		boot_spd_set_symbs(h, spdid, ci);
-	}
+	return cos_vect_lookup(&spd_info_addresses, target);
 }
 
 static void
 boot_deps_init(void)
 {
 	cos_vect_init_static(&spd_info_addresses);
+}
+
+static void
+boot_deps_save_hp(spdid_t spdid, void *hp)
+{
+	cinfo_add_heap_pointer(cos_spd_id(), spdid, hp);
 }
 
 static void

--- a/src/components/implementation/no_interface/cbboot/boot_deps.h
+++ b/src/components/implementation/no_interface/cbboot/boot_deps.h
@@ -26,19 +26,14 @@
 #include <cinfo.h>
 #include <cos_vect.h>
 
-static int boot_spd_set_symbs(struct cobj_header *h, spdid_t spdid, struct cos_component_information *ci);
-static void
-comp_info_record(struct cobj_header *h, spdid_t spdid, struct cos_component_information *ci)
-{
-	vaddr_t cinfo_addr = (vaddr_t)cinfo_alloc_page(cos_spd_id());
-	if (cinfo_addr != __local_mman_alias_page(cos_spd_id(), (vaddr_t)round_to_page(ci), cinfo_spdid(cos_spd_id()), cinfo_addr, MAPPING_RW)) BUG();
-	if (!cinfo_add(cos_spd_id(), spdid, cinfo_addr)) {
-		boot_spd_set_symbs(h, spdid, ci);
-	}
-}
-
 static void
 boot_deps_init(void) { return; }
+
+static void
+boot_deps_save_hp(spdid_t spdid, void *hp)
+{
+	cinfo_add_heap_pointer(cos_spd_id(), spdid, hp);
+}
 
 static void
 boot_deps_run(void) { return; }

--- a/src/components/implementation/no_interface/cinfo_test/citest.c
+++ b/src/components/implementation/no_interface/cinfo_test/citest.c
@@ -6,29 +6,14 @@
 
 void cos_init(void)
 {
-	void *hp = cos_get_heap_ptr();
 	int i;
 
 	for (i = 0 ; i < MAX_NUM_SPDS ; i++) {
-		struct cos_component_information *ci;
 		spdid_t spdid = (spdid_t)i;
-
-		cos_set_heap_ptr((void*)(((unsigned long)hp)+PAGE_SIZE));
-		//spdid = cinfo_get_spdid(i);
-		//if (!spdid) break;
-
-		if (cinfo_map(cos_spd_id(), (vaddr_t)hp, spdid)) {
-			printc("Could not map cinfo page for %d.\n", spdid);
-			continue;
-		}
-		ci = hp;
-		printc("mapped -- id: %ld, hp:%x, sp:%x\n", 
-		       ci->cos_this_spd_id, (unsigned int)ci->cos_heap_ptr, 
-		       (unsigned int)ci->cos_stacks.freelists[0].freelist);
-
-		hp = cos_get_heap_ptr();
+		void *hp = cinfo_get_heap_pointer(cos_spd_id(), spdid);
+		printc("got heap -- id: %d, hp:%p\n", spdid, hp); 
 	}
-	printc("Done mapping components information pages!\n");
+	printc("Done getting components heap pointers!\n");
 }
 
 void bin (void)

--- a/src/components/implementation/no_interface/llboot/boot_deps.h
+++ b/src/components/implementation/no_interface/llboot/boot_deps.h
@@ -241,16 +241,6 @@ __local_mman_alias_page(spdid_t s_spd, vaddr_t s_addr, spdid_t d_spd, vaddr_t d_
 	return d_addr;
 }
 
-static int boot_spd_set_symbs(struct cobj_header *h, spdid_t spdid, struct cos_component_information *ci);
-static void
-comp_info_record(struct cobj_header *h, spdid_t spdid, struct cos_component_information *ci) 
-{ 
-	if (!comp_boot_nfo[spdid].symbols_initialized) {
-		comp_boot_nfo[spdid].symbols_initialized = 1;
-		boot_spd_set_symbs(h, spdid, ci);
-	}
-}
-
 static inline void boot_create_init_thds(void)
 {
 	struct llbooter_per_core *llboot = PERCPU_GET(llbooter);
@@ -276,6 +266,11 @@ boot_deps_init(void)
 	/* How many memory managers are there? */
 	for (i = 0 ; init_schedule[i] ; i++) nmmgrs += init_mem_access[i];
 	assert(nmmgrs > 0);
+}
+
+static void
+boot_deps_save_hp(spdid_t spdid, void *hp)
+{
 }
 
 static void

--- a/src/components/include/cos_asm_stkmgr_stacks.h
+++ b/src/components/include/cos_asm_stkmgr_stacks.h
@@ -42,6 +42,7 @@
         movl (%eax), %esp;                      \
 	COMP_INFO_CMPXCHG;                      \
         jnz 8b;					\
+5:                                              \
 						\
 	/* now we have the stack */		\
         movl  %eax, %esp;                       \
@@ -80,9 +81,7 @@
         call stkmgr_grant_stack;                \
         addl $4, %esp;                          \
                                                 \
-        /* addl $0x4, %eax; */                  \
-                                                \
-        /*restore stack */                      \
+        /* restore regs */                      \
 	popl %edx;				\
         popl %ecx;                              \
         popl %ebx;                              \
@@ -90,12 +89,11 @@
         popl %esi;                              \
         popl %ebp;                              \
 						\
-        /* movl  %eax, %esp; */                 \
-	/* restore Thd_id in eax */		\
-	/* movl $THD_ID_SHARED_PAGE, %edx; */	\
-        /* movl (%edx), %eax; */		\
-	movl %edx, %eax;			\
-	jmp  1b;                                
+	/* Check for NULL stack return */	\
+        testl %eax, %eax;                       \
+        je    8b;                               \
+	/* Got a stack in eax */		\
+	jmp   5b;                                
 
 #define COS_ASM_RET_STACK                       \
                                                 \

--- a/src/components/interface/cinfo/cinfo.h
+++ b/src/components/interface/cinfo/cinfo.h
@@ -1,11 +1,7 @@
 #ifndef   	CINFO_H
 #define   	CINFO_H
 
-int cinfo_add(spdid_t spdid, spdid_t target, struct cos_component_information *ci);
-void* cinfo_alloc_page(spdid_t spdid);
-int cinfo_map(spdid_t spdid, vaddr_t map_addr, spdid_t target);
-int cinfo_spdid(spdid_t spdid);
-
-/* vaddr_t cinfo_map_peek(spdid_t spdid); */
+int cinfo_add_heap_pointer(spdid_t spdid, spdid_t target, void *hp);
+void* cinfo_get_heap_pointer(spdid_t spdid, spdid_t target);
 
 #endif 	    /* !CINFO_H */

--- a/src/components/interface/cinfo/stubs/s_stub.S
+++ b/src/components/interface/cinfo/stubs/s_stub.S
@@ -9,7 +9,5 @@
 
 .text	
 
-cos_asm_server_stub_spdid(cinfo_add)
-cos_asm_server_stub_spdid(cinfo_alloc_page)
-cos_asm_server_stub_spdid(cinfo_map)
-cos_asm_server_stub_spdid(cinfo_spdid)
+cos_asm_server_stub_spdid(cinfo_add_heap_pointer)
+cos_asm_server_stub_spdid(cinfo_get_heap_pointer)


### PR DESCRIPTION
Remove all uses of cinfo_map() and rewrites cinfo to be a wrapper around obtaining another component's heap pointer. Now cos_comp_info page only needs to be shared between a component and its booter.

Tested with: unit_cbuf, unit_torrent