### PR TITLE
cbboot: cbuf-backed components

### DIFF
--- a/src/components/implementation/cbuf_mgr/default/cbuf_mgr.c
+++ b/src/components/implementation/cbuf_mgr/default/cbuf_mgr.c
@@ -456,11 +456,12 @@ free:
 }
 
 vaddr_t
-cbuf_map_at(spdid_t s_spd, cbuf_t cbid, spdid_t d_spd, vaddr_t d_addr, int flags)
+cbuf_map_at(spdid_t s_spd, cbuf_t cbid, spdid_t d_spd, vaddr_t d_addr)
 {
 	vaddr_t ret = (vaddr_t)NULL;
 	struct cbuf_info *cbi;
 	u32_t id;
+	int flags;
 	
 	cbuf_unpack(cbid, &id);
 	CBUF_TAKE();
@@ -468,8 +469,12 @@ cbuf_map_at(spdid_t s_spd, cbuf_t cbid, spdid_t d_spd, vaddr_t d_addr, int flags
 	assert(cbi);
 	if (unlikely(!cbi)) goto done;
 	assert(cbi->owner.spdid == s_spd);
-	if (valloc_alloc_at(s_spd, d_spd, (void*)d_addr, cbi->size/PAGE_SIZE)) goto done;
-	if (cbuf_map(d_spd, d_addr, cbi->mem, cbi->size, flags)) goto free;
+	// the low-order bits of the d_addr are packed with the MAPPING flags (0/1)
+	// and a flag (2) set if valloc should not be used.
+	flags = d_addr & 0x3;
+	d_addr &= ~0x3;
+	if (!(flags & 2) && valloc_alloc_at(s_spd, d_spd, (void*)d_addr, cbi->size/PAGE_SIZE)) goto done;
+	if (cbuf_map(d_spd, d_addr, cbi->mem, cbi->size, flags & (MAPPING_READ|MAPPING_RW))) goto free;
 	ret = d_addr;
 	/* do not add d_spd to the meta list because the cbuf is not
 	 * accessible directly. The s_spd must maintain the necessary info
@@ -478,7 +483,7 @@ done:
 	CBUF_RELEASE();
 	return ret;
 free:
-	//valloc_free(s_spd, d_spd, d_addr, cbi->size);
+	if (!(flags & 2)) valloc_free(s_spd, d_spd, (void*)d_addr, cbi->size);
 	goto done;
 }
 

--- a/src/components/implementation/cbuf_mgr/default/cbuf_mgr.c
+++ b/src/components/implementation/cbuf_mgr/default/cbuf_mgr.c
@@ -225,8 +225,7 @@ cbuf_alloc_map(spdid_t spdid, vaddr_t *daddr, void **page, int size)
 	dest = (vaddr_t)valloc_alloc(cos_spd_id(), spdid, size/PAGE_SIZE);
 	if (!dest) goto free;
 
-	if (cbuf_map(spdid, dest, p, size, MAPPING_RW)) goto free;
-	goto done;
+	if (!cbuf_map(spdid, dest, p, size, MAPPING_RW)) goto done;
 
 free:
 	if (dest) valloc_free(cos_spd_id(), spdid, (void *)dest, 1);

--- a/src/components/implementation/no_interface/boot/boot_deps.h
+++ b/src/components/implementation/no_interface/boot/boot_deps.h
@@ -31,9 +31,8 @@ COS_VECT_CREATE_STATIC(spd_info_addresses);
 int
 cinfo_add_heap_pointer(spdid_t spdid, spdid_t target, void *heap_pointer)
 {
-	if (cos_vect_lookup(&spd_info_addresses, target)) return -1;
-	cos_vect_add_id(&spd_info_addresses, heap_pointer, target);
-	return 0;
+	cos_vect_del(&spd_info_addresses, target);
+	return cos_vect_add_id(&spd_info_addresses, heap_pointer, target);
 }
 
 void*

--- a/src/components/implementation/no_interface/cbboot/Makefile
+++ b/src/components/implementation/no_interface/cbboot/Makefile
@@ -2,7 +2,7 @@ C_OBJS=booter.o
 ASM_OBJS=
 COMPONENT=cbboot.o
 INTERFACES=failure_notif cgraph
-DEPENDENCIES=sched printc mem_mgr cinfo
+DEPENDENCIES=sched printc mem_mgr cinfo cbuf_mgr
 IF_LIB=
 ADDITIONAL_LIBS=-lcobj_format
 

--- a/src/components/implementation/no_interface/cbboot/boot_deps.h
+++ b/src/components/implementation/no_interface/cbboot/boot_deps.h
@@ -6,6 +6,7 @@
 #include <sched.h>
 #include <cos_alloc.h>
 #include <cobj_format.h>
+#include <cbuf.h>
 
 /* 
  * Abstraction layer around 1) synchronization, 2) scheduling and
@@ -20,8 +21,30 @@
 #define __sched_create_thread_default sched_create_thread_default
 
 /* memory operations... */
-#define __local_mman_get_page   mman_get_page
-#define __local_mman_alias_page mman_alias_page
+#define CBUFS_PER_COMPONENT (1024)
+#define CBBOOT_COMPONENT_CNT (5)
+#define NUM_CBBOOT_CBUFS (CBUFS_PER_COMPONENT * CBBOOT_COMPONENT_CNT)
+static cbuf_t an_array_of_cbufs[NUM_CBBOOT_CBUFS];
+static int index = 0;
+
+static vaddr_t
+__local_mman_get_page(spdid_t spd, vaddr_t addr, int flags)
+{
+	cbuf_t cbid;
+	void *caddr = cbuf_alloc(PAGE_SIZE, &cbid, 0);
+	assert(caddr);
+	assert(index < NUM_CBBOOT_CBUFS);
+	an_array_of_cbufs[index++] = cbid; /* FIXME: track cbufs better */
+	return mman_alias_page(spd, (vaddr_t)caddr, spd, addr, flags);
+}
+
+static vaddr_t
+__local_mman_alias_page(spdid_t s_spd, vaddr_t s_addr, spdid_t d_spd, vaddr_t d_addr, int flags)
+{
+	cbuf_t cbid = an_array_of_cbufs[index-1];
+	// don't need to valloc_alloc_at(d_addr) because it is "reserved"...
+	return cbuf_map_at(s_spd, cbid, d_spd, d_addr | flags | 2);
+}
 
 #include <cinfo.h>
 #include <cos_vect.h>

--- a/src/components/implementation/tests/unit_cbufp/cbufp.c
+++ b/src/components/implementation/tests/unit_cbufp/cbufp.c
@@ -29,7 +29,7 @@ void unit_cbufp_deref(cbuf_t cbuf, int sz)
 
 int unit_cbufp_map_at(cbuf_t cbuf, int sz, spdid_t spdid, vaddr_t buf)
 {
-	vaddr_t d = cbuf_map_at(cos_spd_id(), cbuf, spdid, buf, MAPPING_RW);
+	vaddr_t d = cbuf_map_at(cos_spd_id(), cbuf, spdid, buf | MAPPING_RW);
 	if ( d != buf ) return -EINVAL;
 	return 0;
 }

--- a/src/components/interface/cbuf_mgr/cbuf_mgr.h
+++ b/src/components/interface/cbuf_mgr/cbuf_mgr.h
@@ -28,7 +28,7 @@ vaddr_t cbuf_register(spdid_t spdid, long cbid);
  * The s_spd that calls this function should ensure the memory is not freed.
  * The d_addr must be alloced with sufficient pages to contain the cbuf.
  */
-vaddr_t cbuf_map_at(spdid_t s_spd, cbuf_t cbid, spdid_t d_spd, vaddr_t d_addr, int flags);
+vaddr_t cbuf_map_at(spdid_t s_spd, cbuf_t cbid, spdid_t d_spd, vaddr_t d_addr);
 int cbuf_unmap_at(spdid_t s_spd, cbuf_t cbid, spdid_t d_spd, vaddr_t d_addr);
 
 /*

--- a/src/platform/linux/util/unit_cbboot_cbuf.sh
+++ b/src/platform/linux/util/unit_cbboot_cbuf.sh
@@ -16,7 +16,7 @@ stat.o-cbuf.o|te.o|fprr.o|l.o|print.o|e.o;\
 \
 cbuf.o-boot.o|fprr.o|print.o|l.o|mm.o|va.o|mpool.o;\
 mpool.o-print.o|fprr.o|mm.o|boot.o|va.o|l.o;\
-cbboot.o-print.o|fprr.o|mm.o|boot.o;\
+cbboot.o-print.o|fprr.o|mm.o|boot.o|cbuf.o;\
 vm.o-fprr.o|print.o|mm.o|l.o|boot.o;\
 va.o-fprr.o|print.o|mm.o|l.o|boot.o|vm.o;\
 ucbuf1.o-fprr.o|ucbuf2.o|ucbufp.o|print.o|mm.o|va.o|cbuf.o|l.o;\


### PR DESCRIPTION
There are two main changes here, two bug fixes, and a bit of reformatting.

One bug fix is for cbuf_map_at() where the interface was trying to use too many arguments. Now the 'flags' field, which is used to specify MAPPING_READ or MAPPING_RW, is stashed in the low-order bits of the virtual address used for the map destination. Note: we could use even more bits if we want to enforce that all cbuf_map_at() are page-aligned, which is currently how the interface gets used anyways. I also use another bit of the flags to indicated whether cbuf_map_at() should also reserve the mapped address in the destination component using valloc_alloc_at(), or not.

Another bug fix is in the booter code, which was not updating the stored heap pointer correctly when it was modified within the booter via access to the cos_comp_info. **Note: there may still be problems if the heap pointer is modified in cos_comp_info and cinfo_set_heap_pointer() is not also called.**

The changes:
1. Refactor the booter logic to first allocate memory, then map it, then populate it. Previously, the booter would allocate+map, and then populate. Splitting allocation makes it easier to ensure a contiguous address space for booted components in higher-level booters, which simplifies the map and populate logic.
2. Use cbufs as the backing storage for components booted by cbboot. The cbboot component now cbuf_alloc()s page-sized cbufs instead of using mman_get_page. The cbuf's memory is mman_alias()ed into cbboot overlapping with the pre-allocated contiguous region that booter expects to use to populate component memory. **Note: cbboot uses about twice as much memory because it allocates both a contiguous region AND cbufs for component memory.** If memory pressure becomes a problem, we can probably think of some ways to remove the duplication. Also, the cbufs that get allocated are currently just tracked through a massive array, which should be improved in the future. **The array of cbufs is currently static-allocated with an estimated size that should be made either dynamic or statically-bounded.** However, for the current users of cbboot (unit_cbboot_cbuf.sh), the current solution works fine.

Tested with unit_cbboot_cbuf.sh.