### PR TITLE
bug fix cbuf, valloc, bitmap and cvect

### DIFF
--- a/src/components/implementation/cbuf_mgr/default/cbuf_mgr.c
+++ b/src/components/implementation/cbuf_mgr/default/cbuf_mgr.c
@@ -218,7 +218,7 @@ cbuf_alloc_map(spdid_t spdid, vaddr_t *daddr, void **page, int size)
 	int ret = 0;
 
 	assert(size == (int)round_to_page(size));
-	p = alloc_page();
+	p = page_alloc(size/PAGE_SIZE);
 	if (!p) goto done;
 	memset(p, 0, size);
 
@@ -230,7 +230,7 @@ cbuf_alloc_map(spdid_t spdid, vaddr_t *daddr, void **page, int size)
 free:
 	if (dest) valloc_free(cos_spd_id(), spdid, (void *)dest, 1);
 	dest = 0;
-	free_page(p);
+	page_free(p, size/PAGE_SIZE);
 	p = 0;
 	ret = -1;
 done:

--- a/src/components/implementation/valloc/simple/valloc.c
+++ b/src/components/implementation/valloc/simple/valloc.c
@@ -84,6 +84,7 @@ static int __valloc_init(spdid_t spdid)
         trac->extents[0].map   = occ;
         page_off = ((unsigned long)hp - (unsigned long)round_to_pgd_page(hp))/PAGE_SIZE;
         bitmap_set_contig(&occ->pgd_occupied[0], page_off, (PGD_SIZE/PAGE_SIZE)-page_off, 1);
+        bitmap_set_contig(&occ->pgd_occupied[0], 0, page_off, 0);
 
 	cos_vect_add_id(&spd_vect, trac, spdid);
 	assert(cos_vect_lookup(&spd_vect, spdid));

--- a/src/components/include/bitmap.h
+++ b/src/components/include/bitmap.h
@@ -220,7 +220,7 @@ bitmap_contiguous_ones(u32_t *x, int off, int extent, int max)
 		/* uncontiguous? */
 		else if (i != prev) start = i;
 		/* found an appropriate extent? */
-		else if (i-start == extent) return start;
+		else if (i-start+1 >= extent) return start;
 	}
 	return -1;
 }

--- a/src/components/include/cvect.h
+++ b/src/components/include/cvect.h
@@ -244,6 +244,7 @@ __cvect_expand_rec(struct cvect_intern *vi, const long id, const int depth)
 		if (vi[n & CVECT_MASK].c.next == NULL) {
 			struct cvect_intern *new = CVECT_ALLOC();
 			if (!new) return -1;
+			memset(new, 0, PAGE_SIZE);
 			vi[n & CVECT_MASK].c.next = new;
 		}
 		return __cvect_expand_rec(vi[n & CVECT_MASK].c.next, id, depth-1);


### PR DESCRIPTION
In bitmap_contiguous_ones function in bitmap
1. There are (i-start+1) 1s from start to i.
2. However even if I change it to (i-start+1 == extent), it is still broken when externt=1.
   The reason is, if i != prev, start becomes to i, and i becomes i+1 in next loop.
   So i-start+1 is at least 2, can be never be equal to 1.

In  __valloc_init function,
We only initialize the bitmap after heap pointer(hp), but we search for available virtual address from the 
beginning of the bitmap. If there are something left in the page backed this bitmap, we may find a address 
which is being used.
In fact, in my test, if I write something to a cbuf and unmap that cbuf, there is a fault. This is because the page for the cbuf is allocated to the bitmap.

There is a same problem In cvect_expand. We forget to zero out that page, and later on some vect_look up may fail. I met this bug last year when I debug CCV. I just remember this when I got above valloc issue.

Test by micro_cbuf, unit_cbuf and unit_cbboot_cbuf
