### PR TITLE
Cbboot sect

### DIFF
--- a/src/components/implementation/no_interface/boot/boot_deps.h
+++ b/src/components/implementation/no_interface/boot/boot_deps.h
@@ -48,7 +48,7 @@ boot_deps_init(void)
 }
 
 static void
-boot_deps_map_pages(spdid_t spdid, void *src_start, vaddr_t dest_start, int pages)
+boot_deps_map_sect(spdid_t spdid, void *src_start, vaddr_t dest_start, int pages, int sect_id, int sects)
 {
 	char *dsrc = src_start;
 	vaddr_t dest_daddr = dest_start;
@@ -62,7 +62,6 @@ boot_deps_map_pages(spdid_t spdid, void *src_start, vaddr_t dest_start, int page
 		dsrc += PAGE_SIZE;
 		dest_daddr += PAGE_SIZE;
 	}
-	return 0;
 }
 
 static void

--- a/src/components/implementation/no_interface/boot/boot_deps.h
+++ b/src/components/implementation/no_interface/boot/boot_deps.h
@@ -48,7 +48,7 @@ boot_deps_init(void)
 }
 
 static void
-boot_deps_map_sect(spdid_t spdid, void *src_start, vaddr_t dest_start, int pages, int sect_id, int sects)
+boot_deps_map_sect(spdid_t spdid, void *src_start, vaddr_t dest_start, int pages, struct cobj_header *h, int sect_id)
 {
 	char *dsrc = src_start;
 	vaddr_t dest_daddr = dest_start;

--- a/src/components/implementation/no_interface/boot/boot_deps.h
+++ b/src/components/implementation/no_interface/boot/boot_deps.h
@@ -48,17 +48,24 @@ boot_deps_init(void)
 }
 
 static void
-boot_deps_map_sect(spdid_t spdid, void *src_start, vaddr_t dest_start, int pages, struct cobj_header *h, int sect_id)
+boot_deps_map_sect(spdid_t spdid, void *src_start, vaddr_t dest_start, int pages, struct cobj_header *h, unsigned int sect_id)
 {
 	char *dsrc = src_start;
 	vaddr_t dest_daddr = dest_start;
+	struct cobj_sect *sect;
+	int flags;
+	
+	sect = cobj_sect_get(h, sect_id);
+	if (sect->flags & COBJ_SECT_WRITE) flags = MAPPING_RW;
+	else flags = MAPPING_READ;
+	
 	assert(pages > 0);
 	while (pages-- > 0) {
 		/* TODO: if use_kmem, we should allocate
 		 * kernel-accessible memory, rather than
 		 * normal user-memory */
 		if ((vaddr_t)dsrc != __local_mman_get_page(cos_spd_id(), (vaddr_t)dsrc, MAPPING_RW)) BUG();
-		if (dest_daddr != (__local_mman_alias_page(cos_spd_id(), (vaddr_t)dsrc, spdid, dest_daddr, MAPPING_RW))) BUG();
+		if (dest_daddr != (__local_mman_alias_page(cos_spd_id(), (vaddr_t)dsrc, spdid, dest_daddr, flags))) BUG();
 		dsrc += PAGE_SIZE;
 		dest_daddr += PAGE_SIZE;
 	}

--- a/src/components/implementation/no_interface/boot/boot_deps.h
+++ b/src/components/implementation/no_interface/boot/boot_deps.h
@@ -48,6 +48,24 @@ boot_deps_init(void)
 }
 
 static void
+boot_deps_map_pages(spdid_t spdid, void *src_start, vaddr_t dest_start, int pages)
+{
+	char *dsrc = src_start;
+	vaddr_t dest_daddr = dest_start;
+	assert(pages > 0);
+	while (pages-- > 0) {
+		/* TODO: if use_kmem, we should allocate
+		 * kernel-accessible memory, rather than
+		 * normal user-memory */
+		if ((vaddr_t)dsrc != __local_mman_get_page(cos_spd_id(), (vaddr_t)dsrc, MAPPING_RW)) BUG();
+		if (dest_daddr != (__local_mman_alias_page(cos_spd_id(), (vaddr_t)dsrc, spdid, dest_daddr, MAPPING_RW))) BUG();
+		dsrc += PAGE_SIZE;
+		dest_daddr += PAGE_SIZE;
+	}
+	return 0;
+}
+
+static void
 boot_deps_save_hp(spdid_t spdid, void *hp)
 {
 	cinfo_add_heap_pointer(cos_spd_id(), spdid, hp);

--- a/src/components/implementation/no_interface/boot/booter.c
+++ b/src/components/implementation/no_interface/boot/booter.c
@@ -211,7 +211,7 @@ boot_spd_map_memory(struct cobj_header *h, spdid_t spdid, vaddr_t comp_info)
 		if (left > 0) {
 			left = round_up_to_page(left);
 			prev_map = dest_daddr;
-			boot_deps_map_pages(spdid, dsrc, dest_daddr, left/PAGE_SIZE);
+			boot_deps_map_sect(spdid, dsrc, dest_daddr, left/PAGE_SIZE, i, h->nsect);
 			prev_map += left - PAGE_SIZE;
 			dest_daddr += left;
 			dsrc += left;

--- a/src/components/implementation/no_interface/boot/booter.c
+++ b/src/components/implementation/no_interface/boot/booter.c
@@ -211,7 +211,7 @@ boot_spd_map_memory(struct cobj_header *h, spdid_t spdid, vaddr_t comp_info)
 		if (left > 0) {
 			left = round_up_to_page(left);
 			prev_map = dest_daddr;
-			boot_deps_map_sect(spdid, dsrc, dest_daddr, left/PAGE_SIZE, i, h->nsect);
+			boot_deps_map_sect(spdid, dsrc, dest_daddr, left/PAGE_SIZE, h, i);
 			prev_map += left - PAGE_SIZE;
 			dest_daddr += left;
 			dsrc += left;

--- a/src/components/implementation/no_interface/boot/booter.c
+++ b/src/components/implementation/no_interface/boot/booter.c
@@ -184,24 +184,6 @@ boot_spd_alloc_memory(struct cobj_header *h, spdid_t spdid, vaddr_t comp_info)
 	return 0;
 }
 
-static void
-boot_deps_map_pages(spdid_t spdid, void *src_start, vaddr_t dest_start, int pages)
-{
-	char *dsrc = src_start;
-	vaddr_t dest_daddr = dest_start;
-	assert(pages > 0);
-	while (pages-- > 0) {
-		/* TODO: if use_kmem, we should allocate
-		 * kernel-accessible memory, rather than
-		 * normal user-memory */
-		if ((vaddr_t)dsrc != __local_mman_get_page(cos_spd_id(), (vaddr_t)dsrc, MAPPING_RW)) BUG();
-		if (dest_daddr != (__local_mman_alias_page(cos_spd_id(), (vaddr_t)dsrc, spdid, dest_daddr, MAPPING_RW))) BUG();
-		dsrc += PAGE_SIZE;
-		dest_daddr += PAGE_SIZE;
-	}
-	return 0;
-}
-
 static int
 boot_spd_map_memory(struct cobj_header *h, spdid_t spdid, vaddr_t comp_info)
 {

--- a/src/components/implementation/no_interface/boot/booter.c
+++ b/src/components/implementation/no_interface/boot/booter.c
@@ -470,8 +470,9 @@ failure_notif_fail(spdid_t caller, spdid_t failed)
 	UNLOCK();
 }
 
+#define MAX_DEP (PAGE_SIZE/sizeof(struct deps))
 struct deps { short int client, server; };
-struct deps *deps;
+struct deps deps[MAX_DEP];
 int ndeps;
 
 int
@@ -488,7 +489,6 @@ cgraph_client(int iter)
 	return deps[iter].client;
 }
 
-#define MAX_DEP (PAGE_SIZE/sizeof(struct deps))
 int
 cgraph_add(int serv, int client)
 {
@@ -510,7 +510,7 @@ void cos_init(void)
 	h         = (struct cobj_header *)cos_comp_info.cos_poly[0];
 	num_cobj  = (int)cos_comp_info.cos_poly[1];
 
-	deps      = (struct deps *)cos_comp_info.cos_poly[2];
+	memcpy(deps, (struct deps *)cos_comp_info.cos_poly[2], PAGE_SIZE);
 	for (i = 0 ; deps[i].server ; i++) ;
 	ndeps     = i;
 	init_args = (struct component_init_str *)cos_comp_info.cos_poly[3];

--- a/src/components/implementation/no_interface/cbboot/boot_deps.h
+++ b/src/components/implementation/no_interface/cbboot/boot_deps.h
@@ -53,6 +53,24 @@ static void
 boot_deps_init(void) { return; }
 
 static void
+boot_deps_map_pages(spdid_t spdid, void *src_start, vaddr_t dest_start, int pages)
+{
+	char *dsrc = src_start;
+	vaddr_t dest_daddr = dest_start;
+	assert(pages > 0);
+	while (pages-- > 0) {
+		/* TODO: if use_kmem, we should allocate
+		 * kernel-accessible memory, rather than
+		 * normal user-memory */
+		if ((vaddr_t)dsrc != __local_mman_get_page(cos_spd_id(), (vaddr_t)dsrc, MAPPING_RW)) BUG();
+		if (dest_daddr != (__local_mman_alias_page(cos_spd_id(), (vaddr_t)dsrc, spdid, dest_daddr, MAPPING_RW))) BUG();
+		dsrc += PAGE_SIZE;
+		dest_daddr += PAGE_SIZE;
+	}
+	return 0;
+}
+
+static void
 boot_deps_save_hp(spdid_t spdid, void *hp)
 {
 	cinfo_add_heap_pointer(cos_spd_id(), spdid, hp);

--- a/src/components/implementation/no_interface/cbboot/boot_deps.h
+++ b/src/components/implementation/no_interface/cbboot/boot_deps.h
@@ -24,6 +24,7 @@
 #include <cos_vect.h>
 
 COS_VECT_CREATE_STATIC(spd_sect_cbufs);
+COS_VECT_CREATE_STATIC(spd_sect_cbufs_size);
 
 /* Need static storage for tracking cbufs to avoid dynamic allocation
  * before boot_deps_map_sect finishes. Each spd has probably 12 or so
@@ -38,6 +39,7 @@ static void
 boot_deps_init(void)
 {
 	cos_vect_init_static(&spd_sect_cbufs);
+	cos_vect_init_static(&spd_sect_cbufs_size);
 }
 
 static void
@@ -60,6 +62,7 @@ boot_deps_map_sect(spdid_t spdid, void *src_start, vaddr_t dest_start, int pages
 		sect_cbufs = &all_spd_sect_cbufs[all_cbufs_index];
 		all_cbufs_index += sects;
 		if (cos_vect_add_id(&spd_sect_cbufs, sect_cbufs, spdid) < 0) BUG();
+		if (cos_vect_add_id(&spd_sect_cbufs_size, sects, spdid) < 0) BUG();
 	}
 
 	assert(sect_cbufs);

--- a/src/components/implementation/no_interface/cbboot/boot_deps.h
+++ b/src/components/implementation/no_interface/cbboot/boot_deps.h
@@ -34,7 +34,7 @@ static void
 boot_deps_init(void) { return; }
 
 static void
-boot_deps_map_pages(spdid_t spdid, void *src_start, vaddr_t dest_start, int pages)
+boot_deps_map_sect(spdid_t spdid, void *src_start, vaddr_t dest_start, int pages, int sect_id, int sects)
 {
 	cbuf_t cbid;
 	vaddr_t dsrc = (vaddr_t)src_start;

--- a/src/components/implementation/no_interface/cbboot/boot_deps.h
+++ b/src/components/implementation/no_interface/cbboot/boot_deps.h
@@ -43,7 +43,7 @@ boot_deps_init(void)
 }
 
 static void
-boot_deps_map_sect(spdid_t spdid, void *src_start, vaddr_t dest_start, int pages, struct cobj_header *h, int sect_id)
+boot_deps_map_sect(spdid_t spdid, void *src_start, vaddr_t dest_start, int pages, struct cobj_header *h, unsigned int sect_id)
 {
 	cbuf_t cbid, *sect_cbufs;
 	char *caddr;
@@ -56,12 +56,11 @@ boot_deps_map_sect(spdid_t spdid, void *src_start, vaddr_t dest_start, int pages
 	dest = dest_start;
 	sect = cobj_sect_get(h, sect_id);
 
-	assert(pages > 0);
-
 	if (sect->flags & COBJ_SECT_WRITE) flags = MAPPING_RW;
 	else flags = MAPPING_READ;
 	flags |= 2; /* no valloc */
 
+	assert(pages > 0);
 	caddr = cbuf_alloc_ext(pages * PAGE_SIZE, &cbid, CBUF_EXACTSZ);
 	assert(caddr);
 
@@ -70,7 +69,7 @@ boot_deps_map_sect(spdid_t spdid, void *src_start, vaddr_t dest_start, int pages
 		sect_cbufs = &all_spd_sect_cbufs[all_cbufs_index];
 		all_cbufs_index += h->nsect;
 		if (cos_vect_add_id(&spd_sect_cbufs, sect_cbufs, spdid) < 0) BUG();
-		if (cos_vect_add_id(&spd_sect_cbufs_size, h->nsect, spdid) < 0) BUG();
+		if (cos_vect_add_id(&spd_sect_cbufs_size, (void*)h->nsect, spdid) < 0) BUG();
 	}
 
 	assert(sect_cbufs);

--- a/src/components/implementation/no_interface/llboot/boot_deps.h
+++ b/src/components/implementation/no_interface/llboot/boot_deps.h
@@ -269,6 +269,24 @@ boot_deps_init(void)
 }
 
 static void
+boot_deps_map_pages(spdid_t spdid, void *src_start, vaddr_t dest_start, int pages)
+{
+	char *dsrc = src_start;
+	vaddr_t dest_daddr = dest_start;
+	assert(pages > 0);
+	while (pages-- > 0) {
+		/* TODO: if use_kmem, we should allocate
+		 * kernel-accessible memory, rather than
+		 * normal user-memory */
+		if ((vaddr_t)dsrc != __local_mman_get_page(cos_spd_id(), (vaddr_t)dsrc, MAPPING_RW)) BUG();
+		if (dest_daddr != (__local_mman_alias_page(cos_spd_id(), (vaddr_t)dsrc, spdid, dest_daddr, MAPPING_RW))) BUG();
+		dsrc += PAGE_SIZE;
+		dest_daddr += PAGE_SIZE;
+	}
+	return 0;
+}
+
+static void
 boot_deps_save_hp(spdid_t spdid, void *hp)
 {
 }

--- a/src/components/implementation/no_interface/llboot/boot_deps.h
+++ b/src/components/implementation/no_interface/llboot/boot_deps.h
@@ -269,7 +269,7 @@ boot_deps_init(void)
 }
 
 static void
-boot_deps_map_sect(spdid_t spdid, void *src_start, vaddr_t dest_start, int pages, int sect_id, int sects)
+boot_deps_map_sect(spdid_t spdid, void *src_start, vaddr_t dest_start, int pages, struct cobj_header *h, int sect_id)
 {
 	char *dsrc = src_start;
 	vaddr_t dest_daddr = dest_start;

--- a/src/components/implementation/no_interface/llboot/boot_deps.h
+++ b/src/components/implementation/no_interface/llboot/boot_deps.h
@@ -269,7 +269,7 @@ boot_deps_init(void)
 }
 
 static void
-boot_deps_map_pages(spdid_t spdid, void *src_start, vaddr_t dest_start, int pages)
+boot_deps_map_sect(spdid_t spdid, void *src_start, vaddr_t dest_start, int pages, int sect_id, int sects)
 {
 	char *dsrc = src_start;
 	vaddr_t dest_daddr = dest_start;
@@ -283,7 +283,6 @@ boot_deps_map_pages(spdid_t spdid, void *src_start, vaddr_t dest_start, int page
 		dsrc += PAGE_SIZE;
 		dest_daddr += PAGE_SIZE;
 	}
-	return 0;
 }
 
 static void


### PR DESCRIPTION
Allocate cbufs in "sections" at a time rather than pages for cbboot-loaded components. This should make it easier to manage these components. cbboot now also uses read-only mappings for sections that do not have the COBJ_SECT_WRITE flag set.

This is done by refactoring the logic for bood_spd_map_memory() to make a call to a new function in boot_deps.h that must map all of the memory for a section. A side effect is that local_mman calls are no longer used in booter.c, but now there is some duplication of code in boot/boot_deps.h and llboot/boot_deps.h