### PR TITLE
Upcall Component Interface

### DIFF
--- a/src/components/implementation/no_interface/llboot/Makefile
+++ b/src/components/implementation/no_interface/llboot/Makefile
@@ -1,7 +1,7 @@
 C_OBJS=booter.o
 ASM_OBJS=cos_asm_scheduler.o
 COMPONENT=llboot.o
-INTERFACES=cgraph pgfault sched_hier
+INTERFACES=cgraph pgfault sched_hier upcall
 DEPENDENCIES=
 IF_LIB=
 ADDITIONAL_LIBS=-lcobj_format

--- a/src/components/implementation/no_interface/llboot/boot_deps.h
+++ b/src/components/implementation/no_interface/llboot/boot_deps.h
@@ -132,7 +132,7 @@ llboot_thd_done(void)
 			comp_boot_nfo[s].initialized = 1;
 			
 			/* printc("core %ld: booter init_thd upcalling into spdid %d.\n", cos_cpuid(), (unsigned int)s); */
-			cos_upcall(s, 0); /* initialize the component! */
+			cos_upcall(COS_UPCALL_THD_CREATE, s, 0); /* initialize the component! */
 			BUG();
 		}
 		/* Done initializing; reboot!  If we are here, then
@@ -154,7 +154,7 @@ llboot_thd_done(void)
 		if (rspd) {             /* need to recover a component */
 			assert(pthd);
 			llboot->recover_spd = 0;
-			cos_upcall(rspd, 0); /* This will escape from the loop */
+			cos_upcall(COS_UPCALL_THD_CREATE, rspd, 0); /* This will escape from the loop */
 			assert(0);
 		} else {		/* ...done reinitializing...resume */
 			assert(pthd && pthd != tid);
@@ -196,7 +196,7 @@ fault_page_fault_handler(spdid_t spdid, void *fault_addr, int flags, void *ip)
 	 * it to restart the component!  This might even be the
 	 * initial thread.
 	 */
-	cos_upcall(spdid, 0); 	/* FIXME: give back stack... */
+	cos_upcall(COS_UPCALL_THD_CREATE, spdid, 0); /* FIXME: give back stack... */
 	BUG();
 
 	return 0;

--- a/src/components/implementation/sched/cos_sched_base.c
+++ b/src/components/implementation/sched/cos_sched_base.c
@@ -1144,7 +1144,7 @@ static int fp_kill_thd(struct sched_thd *t)
 	assert(!(t->flags & THD_DYING));
 	assert(t->spdid != 0);
 
-	if (cos_upcall(t->spdid, t->init_data)) prints("fprr: error making upcall into spd.\n");
+	if (cos_upcall(COS_UPCALL_THD_CREATE, t->spdid, t->init_data)) prints("fprr: error making upcall into spd.\n");
 	
 	if (t == c) {
 		printc("t: id %d, c: id %d\n",t->id, c->id);

--- a/src/components/implementation/tests/unit_upcall/Makefile
+++ b/src/components/implementation/tests/unit_upcall/Makefile
@@ -1,0 +1,8 @@
+C_OBJS=upcall.o
+COMPONENT=upcall_test.o
+INTERFACES=
+DEPENDENCIES=printc sched upcall
+
+include ../../Makefile.subsubdir
+MANDITORY_LIB=simple_stklib.o
+

--- a/src/components/implementation/tests/unit_upcall/upcall.c
+++ b/src/components/implementation/tests/unit_upcall/upcall.c
@@ -1,0 +1,35 @@
+/**
+ * Copyright 2015 by Gedare Bloom gedare@gwu.edu
+ *
+ * Redistribution of this file is permitted under the GNU General
+ * Public License v2.
+ */
+
+#include <cos_component.h>
+#include <print.h>
+#include <upcall.h>
+
+void cos_init(void)
+{
+	printc("UNIT TEST upcall_invoke\n");
+	upcall_invoke(cos_spd_id(), COS_UPCALL_DESTROY, cos_spd_id(), 2); 
+	printc("UNIT TEST PASSED: upcall_invoke\n");
+	return;
+}
+
+void cos_upcall_fn(upcall_type_t t, void *arg1, void *arg2, void *arg3)
+{
+	static int init = 0;
+	switch (t) {
+	case COS_UPCALL_THD_CREATE:
+		if (init == 0) {
+			init = 1;
+			cos_init();
+			break;
+		}
+	default:
+		printc("Upcall %d\targs (%p, %p, %p)\n", t, arg1, arg2, arg3);
+		break;
+	}
+	return;
+}

--- a/src/components/include/cos_component.h
+++ b/src/components/include/cos_component.h
@@ -138,7 +138,7 @@ cos_syscall_2(4,  int, __switch_thread, int, thd_id, int, flags);
 cos_syscall_3(5, int, __async_cap_cntl, int, operation, int, arg1, long, arg2);
 cos_syscall_1(6, int, ainv_wait, int, acap_id);
 cos_syscall_1(7, int, ainv_send, int, acap_id);
-cos_syscall_2(8,  int, upcall, int, spd_id, int, init_data);
+cos_syscall_2(8,  int, __upcall, int, spd_id, int, init_data);
 cos_syscall_3(9,  int, sched_cntl, int, operation, int, thd_id, long, option);
 cos_syscall_3(10, int, mpd_cntl, int, operation, spdid_t, composite_spd, spdid_t, composite_dest);
 cos_syscall_3(11, int, __mmap_cntl, long, op_flags_dspd, vaddr_t, daddr, unsigned long, mem_id);
@@ -178,6 +178,11 @@ cos_pfn_cntl(short int op, int dest_spd, unsigned int mem_id, int extent) {
 static inline int cos_buff_mgmt(unsigned short int op, void *addr, unsigned short int len, short int thd_id)
 {
 	return cos___buff_mgmt(addr, thd_id, ((len << 16) | (op & 0xFFFF)));
+}
+
+static inline int cos_upcall(upcall_type_t op, spdid_t spd, int arg)
+{
+	return cos___upcall((op<<16)|spd, arg);
 }
 
 static inline int cos_thd_cntl(short int op, short int thd_id, long arg1, long arg2)

--- a/src/components/interface/upcall/Makefile
+++ b/src/components/interface/upcall/Makefile
@@ -1,0 +1,5 @@
+LIB_OBJS=
+LIBS=$(LIB_OBJS:%.o=%.a)
+ASM_STUBS=s_stubupcall.o
+
+include ../Makefile.subdir

--- a/src/components/interface/upcall/stubs/s_stub.S
+++ b/src/components/interface/upcall/stubs/s_stub.S
@@ -1,0 +1,11 @@
+/**
+ * Copyright 2015 by Gedare Bloom, gedare@gwu.edu
+ *
+ * Redistribution of this file is permitted under the GNU General
+ * Public License v2.
+ */
+
+#include <cos_asm_server_stub_simple_stack.h>
+.text	
+
+cos_asm_server_stub_spdid(upcall_invoke)

--- a/src/components/interface/upcall/upcall.h
+++ b/src/components/interface/upcall/upcall.h
@@ -1,0 +1,6 @@
+#ifndef   	UPCALL_H
+#define   	UPCALL_H
+
+int upcall_invoke(spdid_t spdid, upcall_type_t op, spdid_t dest, int arg);
+
+#endif 	    /* !UPCALL_H */

--- a/src/kernel/inv.c
+++ b/src/kernel/inv.c
@@ -1699,13 +1699,17 @@ static int verify_trust(struct spd *truster, struct spd *trustee)
  * to bootstrap. */
 extern void cos_syscall_upcall(void);
 COS_SYSCALL int 
-cos_syscall_upcall_cont(int this_spd_id, int spd_id, int init_data, struct pt_regs **regs)
+cos_syscall_upcall_cont(int this_spd_id, int op_spd, int init_data, struct pt_regs **regs)
 {
 	struct spd *dest, *curr_spd;
 	struct thread *thd;
+	int op, spd_id;
 
 	assert(regs);
 	*regs = NULL;
+
+	op = op_spd >> 16;
+	spd_id = 0xFFFF & op_spd;
 
 	dest = spd_get_by_index(spd_id);
 	thd = core_get_curr_thd();
@@ -1734,7 +1738,7 @@ cos_syscall_upcall_cont(int this_spd_id, int spd_id, int init_data, struct pt_re
 	spd_mpd_ipc_release((struct composite_spd *)thd_get_thd_spdpoly(thd));//curr_spd->composite_spd);
 	//spd_mpd_ipc_take((struct composite_spd *)dest->composite_spd);
 
-	upcall_setup(thd, dest, COS_UPCALL_THD_CREATE, init_data, 0, 0);
+	upcall_setup(thd, dest, op, init_data, 0, 0);
 	*regs = &thd->regs;
 
 	cos_meas_event(COS_MEAS_UPCALLS);

--- a/src/platform/linux/util/unit_upcall.sh
+++ b/src/platform/linux/util/unit_upcall.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+./cos_loader \
+"c0.o, ;llboot.o, ;*fprr.o, ;mm.o, ;print.o, ;boot.o, ;\
+!upcall_test.o, :\
+c0.o-llboot.o;\
+fprr.o-print.o|[parent_]mm.o|[faulthndlr_]llboot.o;\
+mm.o-[parent_]llboot.o|print.o;\
+boot.o-print.o|fprr.o|mm.o|llboot.o;\
+upcall_test.o-print.o|fprr.o|llboot.o\
+" ./gen_client_stub
+


### PR DESCRIPTION
These patches add an interface, implementation, and unit test for a new mechanism, upcall_invoke(), that can make upcalls into arbitrary components at the highest priority passing an upcall type and a single extra argument. This mechanism writes to a structure in the low-level booter and then switches to a dedicated thread that runs at highest priority in llboot. This thread reads the structure to determine the parameters to pass to cos_upcall. The mechanism and code stems from Jiguo's work.

In addition, cos_upcall() is changed to take an upcall_type_t as its first argument, and "recovery" is renamed to "upcall" in the low-level booter to make the upcall framework more general than only used for recovery.