### PR TITLE
Upcall: fix nits

### DIFF
--- a/src/components/implementation/no_interface/llboot/boot_deps.h
+++ b/src/components/implementation/no_interface/llboot/boot_deps.h
@@ -78,8 +78,6 @@ static int     init_mem_access[] = {1, 0, 0};
 static int     nmmgrs            = 0;
 static int     frame_frontier    = 0; /* which physical frames have we used? */
 
-typedef void (*crt_thd_fn_t)(void); /* GB: unused? */
-
 /* 
  * Abstraction layer around 1) synchronization, 2) scheduling and
  * thread creation, and 3) memory operations.  
@@ -97,10 +95,6 @@ typedef void (*crt_thd_fn_t)(void); /* GB: unused? */
 static int
 sched_create_thread_default(spdid_t spdid, u32_t v1, u32_t v2, u32_t v3)
 { return 0; }
-
-/* GB: unused? */
-static void
-llboot_ret_thd(void) { return; }
 
 /* 
  * When a created thread finishes, here we decide what to do with it.
@@ -341,7 +335,6 @@ cos_upcall_fn(upcall_type_t t, void *arg1, void *arg2, void *arg3)
 	/*        cos_cpuid(), cos_get_thd_id(), t, COS_UPCALL_THD_CREATE, COS_UPCALL_DESTROY, COS_UPCALL_UNHANDLED_FAULT); */
 	switch (t) {
 	case COS_UPCALL_THD_CREATE:
-		llboot_ret_thd();
 		break;
 	case COS_UPCALL_DESTROY:
 		llboot_thd_done();

--- a/src/components/implementation/tests/unit_upcall/upcall.c
+++ b/src/components/implementation/tests/unit_upcall/upcall.c
@@ -29,6 +29,8 @@ void cos_upcall_fn(upcall_type_t t, void *arg1, void *arg2, void *arg3)
 		}
 	default:
 		printc("Upcall %d\targs (%p, %p, %p)\n", t, arg1, arg2, arg3);
+		assert(t == COS_UPCALL_DESTROY);
+		assert(arg1 == 2);
 		break;
 	}
 	return;

--- a/src/components/include/cos_component.h
+++ b/src/components/include/cos_component.h
@@ -138,7 +138,7 @@ cos_syscall_2(4,  int, __switch_thread, int, thd_id, int, flags);
 cos_syscall_3(5, int, __async_cap_cntl, int, operation, int, arg1, long, arg2);
 cos_syscall_1(6, int, ainv_wait, int, acap_id);
 cos_syscall_1(7, int, ainv_send, int, acap_id);
-cos_syscall_2(8,  int, __upcall, int, spd_id, int, init_data);
+cos_syscall_3(8,  int, upcall, int, op, int, spd_id, int, init_data);
 cos_syscall_3(9,  int, sched_cntl, int, operation, int, thd_id, long, option);
 cos_syscall_3(10, int, mpd_cntl, int, operation, spdid_t, composite_spd, spdid_t, composite_dest);
 cos_syscall_3(11, int, __mmap_cntl, long, op_flags_dspd, vaddr_t, daddr, unsigned long, mem_id);
@@ -178,11 +178,6 @@ cos_pfn_cntl(short int op, int dest_spd, unsigned int mem_id, int extent) {
 static inline int cos_buff_mgmt(unsigned short int op, void *addr, unsigned short int len, short int thd_id)
 {
 	return cos___buff_mgmt(addr, thd_id, ((len << 16) | (op & 0xFFFF)));
-}
-
-static inline int cos_upcall(upcall_type_t op, spdid_t spd, int arg)
-{
-	return cos___upcall((op<<16)|spd, arg);
 }
 
 static inline int cos_thd_cntl(short int op, short int thd_id, long arg1, long arg2)

--- a/src/kernel/inv.c
+++ b/src/kernel/inv.c
@@ -1699,17 +1699,13 @@ static int verify_trust(struct spd *truster, struct spd *trustee)
  * to bootstrap. */
 extern void cos_syscall_upcall(void);
 COS_SYSCALL int 
-cos_syscall_upcall_cont(int this_spd_id, int op_spd, int init_data, struct pt_regs **regs)
+cos_syscall_upcall_cont(int this_spd_id, upcall_type_t op, int spd_id, int init_data, struct pt_regs **regs)
 {
 	struct spd *dest, *curr_spd;
 	struct thread *thd;
-	int op, spd_id;
 
 	assert(regs);
 	*regs = NULL;
-
-	op = op_spd >> 16;
-	spd_id = 0xFFFF & op_spd;
 
 	dest = spd_get_by_index(spd_id);
 	thd = core_get_curr_thd();

--- a/src/platform/linux/module/ipc.S
+++ b/src/platform/linux/module/ipc.S
@@ -341,11 +341,12 @@ cos_syscall_idle:
 cos_syscall_upcall:
 	pushl $0
 	pushl %esp
+	pushl %edi
 	pushl %esi
 	pushl %ebx /* spd_id to upcall to */
 	pushl %edx /* this spd_id */
 	call cos_syscall_upcall_cont
-	addl $16, %esp
+	addl $20, %esp
 	popl %ebx  /* regs */
 
 	cmpl $-1, %eax


### PR DESCRIPTION
Validate test execution, use cos_upcall_3, and remove unused vars from llboot.