### PR TITLE
Unit pgfault

### DIFF
--- a/src/components/implementation/no_interface/pftest/Makefile
+++ b/src/components/implementation/no_interface/pftest/Makefile
@@ -2,9 +2,10 @@ C_OBJS=pftest.o
 ASM_OBJS=
 COMPONENT=pft.o
 INTERFACES=
-DEPENDENCIES=printc sched pgfault
+DEPENDENCIES=printc sched unit_pgfault
 IF_LIB=
 ADDITIONAL_LIBS=
 
 include ../../Makefile.subsubdir
+MANDITORY_LIB=simple_stklib.o
 

--- a/src/components/implementation/no_interface/pftest/pftest.c
+++ b/src/components/implementation/no_interface/pftest/pftest.c
@@ -1,19 +1,13 @@
 #include <cos_component.h>
 #include <print.h>
 
-#include <pgfault.h>
 #include <sched.h>
 
-int bar(void)
-{
-	int v;
-	v = *((int *)0);
-	return v;
-}
+#include <unit_pgfault.h>
 
 int foo(void) 
 {
-	return bar();
+	return unit_pgfault_page_fault(cos_spd_id());
 }
 
 void cos_init(void)
@@ -22,10 +16,4 @@ void cos_init(void)
 	foo();
 	printc("... and successfully finishing page fault test.\n");
 }
-
-/* void bin (void) */
-/* { */
-/* 	fault_page_fault_handler(cos_spd_id(), NULL, 0, NULL); */
-/* 	sched_block(cos_spd_id(), 0); */
-/* } */
 

--- a/src/components/implementation/pgfault/recov_poc/pgfault.c
+++ b/src/components/implementation/pgfault/recov_poc/pgfault.c
@@ -23,21 +23,23 @@ int fault_page_fault_handler(spdid_t spdid, void *fault_addr, int flags, void *i
 {
 	unsigned long r_ip; 	/* the ip to return to */
 	int tid = cos_get_thd_id();
-	//int i;
 
 	/* START UNCOMMENT FOR FAULT INFO */
-	/* if (regs_active) BUG(); */
-	/* regs_active = 1; */
-	/* cos_regs_save(tid, spdid, fault_addr, &regs); */
-	/* printc("Thread %d faults in spd %d @ %p\n",  */
-	/*        tid, spdid, fault_addr); */
-	/* cos_regs_print(&regs); */
-	/* regs_active = 0; */
+#if 0
+	int i;
+	if (regs_active) BUG();
+	regs_active = 1;
+	cos_regs_save(tid, spdid, fault_addr, &regs);
+	printc("Thread %d faults in spd %d @ %p\n",
+	       tid, spdid, fault_addr);
+	cos_regs_print(&regs);
+	regs_active = 0;
 
-	/* for (i = 0 ; i < 5 ; i++) */
-	/* 	printc("Frame ip:%lx, sp:%lx\n",  */
-	/* 	       cos_thd_cntl(COS_THD_INVFRM_IP, tid, i, 0),  */
-	/* 	       cos_thd_cntl(COS_THD_INVFRM_SP, tid, i, 0)); */
+	for (i = 0 ; i < 5 ; i++) 
+		printc("Frame ip:%lx, sp:%lx\n",
+		       cos_thd_cntl(COS_THD_INVFRM_IP, tid, i, 0),
+		       cos_thd_cntl(COS_THD_INVFRM_SP, tid, i, 0));
+#endif
 	/* END UNCOMMENT FOR FAULT INFO */
 
 	/* remove from the invocation stack the faulting component! */
@@ -49,6 +51,14 @@ int fault_page_fault_handler(spdid_t spdid, void *fault_addr, int flags, void *i
 	/* ...and set it to its value -8, which is the fault handler
 	 * of the stub. */
 	assert(!cos_thd_cntl(COS_THD_INVFRM_SET_IP, tid, 1, r_ip-8));
+
+#if 0
+	for (i = 0 ; i < 5 ; i++) 
+		printc ("after adjusment:\n");
+		printc("Frame ip:%lx, sp:%lx\n",  
+		       cos_thd_cntl(COS_THD_INVFRM_IP, tid, i, 0),
+		       cos_thd_cntl(COS_THD_INVFRM_SP, tid, i, 0));
+#endif
 
 	/* 
 	 * Look at the booter: when recover is happening, the sstub is

--- a/src/components/implementation/tests/unit_pgfault/Makefile
+++ b/src/components/implementation/tests/unit_pgfault/Makefile
@@ -1,0 +1,8 @@
+C_OBJS=unit_pgfault.o
+COMPONENT=upf.o
+INTERFACES=unit_pgfault
+DEPENDENCIES=printc sched pgfault
+
+include ../../Makefile.subsubdir
+MANDITORY_LIB=simple_stklib.o
+

--- a/src/components/implementation/tests/unit_pgfault/pgfault.c
+++ b/src/components/implementation/tests/unit_pgfault/pgfault.c
@@ -1,0 +1,14 @@
+#include <cos_component.h>
+#include <print.h>
+
+#include <unit_pgfault.h>
+
+int unit_pgfault_page_fault(spdid_t spdid)
+{
+	int v;
+	printc("page fault request from spd %d\n", spdid);
+	v = *((int *)0);
+	printc("ERROR: reached past page fault\n");
+	return v;
+}
+

--- a/src/components/interface/unit_pgfault/Makefile
+++ b/src/components/interface/unit_pgfault/Makefile
@@ -1,0 +1,1 @@
+include ../Makefile.subdir

--- a/src/components/interface/unit_pgfault/stubs/s_stub.S
+++ b/src/components/interface/unit_pgfault/stubs/s_stub.S
@@ -1,0 +1,13 @@
+/**
+ * Copyright 2015 Gedare Bloom, gedare@gwu.edu
+ *
+ * Redistribution of this file is permitted under the GNU General
+ * Public License v2.
+ */
+
+#include <cos_asm_server_stub_simple_stack.h>
+
+.text
+
+cos_asm_server_stub_spdid(unit_pgfault_page_fault)
+

--- a/src/components/interface/unit_pgfault/unit_pgfault.h
+++ b/src/components/interface/unit_pgfault/unit_pgfault.h
@@ -1,0 +1,8 @@
+#ifndef UNIT_PGFAULT_H
+#define UNIT_PGFAULT_H
+
+#include <cos_component.h>
+
+int unit_pgfault_page_fault(spdid_t spdid);
+
+#endif /* !UNIT_PGFAULT_H */

--- a/src/kernel/spd.c
+++ b/src/kernel/spd.c
@@ -494,7 +494,7 @@ int spd_cap_set_dest(struct spd *spd, int cap, struct spd* dspd)
 int spd_cap_set_fault_handler(struct spd *spd, int cap, int handler_num)
 {
 	if (handler_num >= COS_FLT_MAX || handler_num < 0) return -1;
-	spd->fault_handler[handler_num] = cap;
+	spd->fault_handler[handler_num] = ++cap;
 
 	return 0;
 }

--- a/src/platform/linux/util/unit_pgfault.sh
+++ b/src/platform/linux/util/unit_pgfault.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+
+./cos_loader \
+"c0.o, ;llboot.o, ;*fprr.o, ;mm.o, ;print.o, ;boot.o, ;\
+!pfr.o, ;!upf.o, ;!pft.o,a10:\
+c0.o-llboot.o;\
+fprr.o-print.o|[parent_]mm.o|[faulthndlr_]llboot.o;\
+mm.o-[parent_]llboot.o|print.o;\
+boot.o-print.o|fprr.o|mm.o|llboot.o;\
+pfr.o-print.o|fprr.o|mm.o|boot.o;\
+upf.o-print.o|fprr.o|pfr.o;\
+pft.o-print.o|fprr.o|pfr.o|upf.o\
+" ./gen_client_stub
+


### PR DESCRIPTION
Add a new unit test for page fault handling. This test revealed a latent off-by-1 bug in the fault_handler lookup within fault_ipc_invoke(), which I fixed in the second commit.