### PR TITLE
support constructor and destructor under gcc 4.8

### DIFF
--- a/src/components/implementation/comp.ld
+++ b/src/components/implementation/comp.ld
@@ -16,6 +16,22 @@ SECTIONS
 		LONG(0)
 		__DTOR_END__ = .;
 	}	
+	.init_array : {
+		__INIT_ARRAY_LIST__ = .;				
+		LONG((__INIT_ARRAY_END__ - __INIT_ARRAY_LIST__) / 4 - 2)
+		KEEP (*(SORT(.init_array.*)))
+		KEEP (*(.init_array))
+		LONG(0)
+		__INIT_ARRAY_END__ = .;
+	}
+	.fini_array : {
+		__FINI_ARRAY_LIST__ = .;				
+		LONG((__FINI_ARRAY_END__ - __FINI_ARRAY_LIST__) / 4 - 2)
+		KEEP (*(.fini_array))
+		KEEP (*(SORT(.fini_array.*)))
+		LONG(0)
+		__FINI_ARRAY_END__ = .;
+	}
 	.crecov : {
 		__CRECOV_LIST__ = .;				
 		LONG((__CRECOV_END__ - __CRECOV_LIST__) / 4 - 2)

--- a/src/components/include/cos_component.h
+++ b/src/components/include/cos_component.h
@@ -421,13 +421,17 @@ static void
 constructors_execute(void)
 {
 	extern long __CTOR_LIST__;
+	extern long __INIT_ARRAY_LIST__;
 	section_fnptrs_execute(&__CTOR_LIST__);
+	section_fnptrs_execute(&__INIT_ARRAY_LIST__);
 }
 static void 
 destructors_execute(void)
 {
 	extern long __DTOR_LIST__;
+	extern long __FINI_ARRAY_LIST__;
 	section_fnptrs_execute(&__DTOR_LIST__);
+	section_fnptrs_execute(&__FINI_ARRAY_LIST__);
 }
 static void 
 recoveryfns_execute(void)

--- a/src/platform/linux/link_load/cos_loader.c
+++ b/src/platform/linux/link_load/cos_loader.c
@@ -147,7 +147,7 @@ typedef enum {
 	RODATA_S, 
 	CTORS_S, 
 	DTORS_S, 
-	INIT_ARRAR_S,
+	INIT_ARRAY_S,
 	FINI_ARRAY_S,
 	CRECOV_S, 
 	KMEM_S, 
@@ -197,7 +197,7 @@ struct cos_sections section_info[MAXSEC_S+1] = {
 		.sname      = ".dtors",
 	},
  	{
-		.secid      = INIT_ARRAR_S,
+		.secid      = INIT_ARRAY_S,
 		.cobj_flags = COBJ_SECT_READ | COBJ_SECT_INITONCE,
 		.coalesce   = 1,
 		.sname      = ".init_array",

--- a/src/platform/linux/link_load/cos_loader.c
+++ b/src/platform/linux/link_load/cos_loader.c
@@ -147,6 +147,8 @@ typedef enum {
 	RODATA_S, 
 	CTORS_S, 
 	DTORS_S, 
+	INIT_ARRAR_S,
+	FINI_ARRAY_S,
 	CRECOV_S, 
 	KMEM_S, 
 	CINFO_S, 
@@ -193,6 +195,18 @@ struct cos_sections section_info[MAXSEC_S+1] = {
 		.cobj_flags = COBJ_SECT_READ | COBJ_SECT_INITONCE,
 		.coalesce   = 1,
 		.sname      = ".dtors",
+	},
+ 	{
+		.secid      = INIT_ARRAR_S,
+		.cobj_flags = COBJ_SECT_READ | COBJ_SECT_INITONCE,
+		.coalesce   = 1,
+		.sname      = ".init_array",
+	},
+	{
+		.secid      = FINI_ARRAY_S,
+		.cobj_flags = COBJ_SECT_READ | COBJ_SECT_INITONCE,
+		.coalesce   = 1,
+		.sname      = ".fini_array",
 	},
 	{
 		.secid      = CRECOV_S,


### PR DESCRIPTION
After 4.8, gcc puts constructor and destructor into init_array and fini_array section, instead of ctors and dtors.
Test with cbuf constructor in cbuf_mgr.