### PR TITLE
Changes to run on bare-metal

### DIFF
--- a/src/kernel/include/thd.h
+++ b/src/kernel/include/thd.h
@@ -204,6 +204,7 @@ thd_activate(struct captbl *t, capid_t cap, capid_t capin, struct thread *thd, c
 	struct cap_comp *compc;
 	int ret;
 
+	memset(thd, 0, sizeof(struct thread));
 	compc = (struct cap_comp *)captbl_lkup(t, compcap);
 	if (unlikely(!compc || compc->h.type != CAP_COMP)) return -EINVAL;
 

--- a/src/platform/i386/Makefile
+++ b/src/platform/i386/Makefile
@@ -41,7 +41,8 @@ OBJS += serial.o
 OBJS += timer.o
 OBJS += chal.o
 OBJS += boot_comp.o
-OBJS += console.o
+#OBJS += console.o
+OBJS += vga.o
 
 COS_OBJ += pgtbl.o
 COS_OBJ += retype_tbl.o

--- a/src/platform/i386/entry.S
+++ b/src/platform/i386/entry.S
@@ -141,6 +141,7 @@ fn##_irq: 			\
 
 .text
 IRQ_CODE(page_fault)
+IRQ_CODE(double_fault)
 IRQ(timer)
 IRQ(keyboard)
 IRQ(serial)

--- a/src/platform/i386/isr.h
+++ b/src/platform/i386/isr.h
@@ -6,11 +6,13 @@
 #include "chal_asm_inc.h"
 
 enum {
+	IRQ_DOUBLE_FAULT = 8,
 	IRQ_PAGE_FAULT = 14,
 	IRQ_PIT        = 32,
 	IRQ_KEYBOARD   = 33,
 	IRQ_SERIAL     = 36
 };
+extern void double_fault_irq(struct pt_regs *);
 extern void page_fault_irq(struct pt_regs *);
 extern void timer_irq(struct pt_regs *);
 extern void keyboard_irq(struct pt_regs *);

--- a/src/platform/i386/kernel.c
+++ b/src/platform/i386/kernel.c
@@ -13,6 +13,10 @@
 #include <component.h>
 #include <thd.h>
 
+#define ADDR_STR_LEN	8
+#define CMDLINE_MAX_LEN	32
+#define CMDLINE_REQ_LEN	(ADDR_STR_LEN * 2 + 1)
+
 struct mem_layout glb_memlayout;
 
 static int
@@ -68,14 +72,19 @@ kern_memory_setup(struct multiboot *mb, u32_t mboot_magic)
 	for (i = 0 ; i < mb->mods_count ; i++) {
 		struct multiboot_mod_list *mod = &mods[i];
 
-		printk("\t- %d: [%08x, %08x)", i, mod->mod_start, mod->mod_end);
+		char *cmdline = (char *)mod->cmdline;
+		int cmdline_len = strnlen((const char*)cmdline, CMDLINE_MAX_LEN);
+		assert(cmdline_len >= CMDLINE_REQ_LEN);
+		int addr_offset = cmdline_len - CMDLINE_REQ_LEN;
+
+		printk("\t- %d: [%08x, %08x) : %s", i, mod->mod_start, mod->mod_end, mod->cmdline);
 		/* These values have to be higher-half addresses */
 		glb_memlayout.mod_start = chal_pa2va((paddr_t)mod->mod_start);
 		glb_memlayout.mod_end   = chal_pa2va((paddr_t)mod->mod_end);
 
-		glb_memlayout.bootc_vaddr = (void*)hextol((char*)mod->cmdline);
-		assert(((char*)mod->cmdline)[8] == '-');
-		glb_memlayout.bootc_entry = (void*)hextol(&(((char*)mod->cmdline)[9]));
+		glb_memlayout.bootc_vaddr = (void*)hextol((char *)(cmdline + addr_offset));
+		assert(cmdline[addr_offset + ADDR_STR_LEN] == '-');
+		glb_memlayout.bootc_entry = (void*)hextol((char *)(cmdline + addr_offset + ADDR_STR_LEN + 1));
 		printk(" @ virtual address %p, _start = %p.\n",
 		       glb_memlayout.bootc_vaddr, glb_memlayout.bootc_entry);
 	}
@@ -90,7 +99,7 @@ kern_memory_setup(struct multiboot *mb, u32_t mboot_magic)
 	/* FIXME: check memory layout vs. the multiboot memory regions... */
 
 	/* Validate the memory layout. */
-	assert(mem_kern_end()   == mem_bootc_start());
+	assert(mem_kern_end()   <= mem_bootc_start());
 	assert(mem_bootc_end()  <= mem_boot_start());
 	assert(mem_boot_start() >= mem_kmem_start());
 	assert(mem_kmem_start() == mem_bootc_start());
@@ -123,6 +132,9 @@ kmain(struct multiboot *mboot, u32_t mboot_magic, u32_t esp)
 #ifdef ENABLE_CONSOLE
 	console_init();
 #endif
+#ifdef ENABLE_VGA
+	vga_init();
+#endif
 #ifdef ENABLE_TIMER
 	timer_init(100);
 #endif
@@ -138,6 +150,9 @@ kmain(struct multiboot *mboot, u32_t mboot_magic, u32_t esp)
        	comp_init();
        	thd_init();
 	paging_init();
+#ifdef ENABLE_VGA
+	vga_high_init();
+#endif
 
 	kern_boot_comp();
 	kern_boot_upcall();
@@ -149,6 +164,7 @@ void
 khalt(void)
 {
 	printk("Shutting down...\n");
+	FOREVER;
 	asm("mov $0x53,%ah");
 	asm("mov $0x07,%al");
 	asm("mov $0x001,%bx");

--- a/src/platform/i386/kernel.h
+++ b/src/platform/i386/kernel.h
@@ -15,10 +15,20 @@
     khalt();				\
 } while(0)
 
+/* only one VGA driver at a time.. */
+#define ENABLE_VGA
+#undef ENABLE_CONSOLE
+
 #ifdef ENABLE_CONSOLE
 void vga_clear(void);
 void vga_puts(const char *s);
 void console_init(void);
+#endif
+
+#ifdef ENABLE_VGA
+void vga_init(void);
+void vga_high_init(void);
+void vga_puts(const char *str);
 #endif
 
 #ifdef ENABLE_SERIAL
@@ -41,5 +51,7 @@ void kern_paging_map_init(void *pa);
 int printk_register_handler(void (*handler)(const char *));
 
 void khalt(void);
+
+#define FOREVER while(1)
 
 #endif /* KERNEL_H */

--- a/src/platform/i386/vga.c
+++ b/src/platform/i386/vga.c
@@ -1,0 +1,204 @@
+#define ENABLE_VGA
+/*
+ * Phani: 09/17/2015
+ *
+ * Code reuse:
+ * from: http://www.osdever.net/bkerndev/index.php 
+ * from: https://www.gnu.org/software/grub/manual/multiboot/multiboot.html#kernel_002ec
+ *
+ */
+
+#include <chal.h>
+#include "kernel.h"
+#include "string.h"
+#include "io.h"
+#include "isr.h"
+
+#define STRLEN_MAX (81)
+
+/* The number of columns. */
+#define COLUMNS                 80
+/* The number of lines. */
+#define LINES                   25
+/* The attribute of an character. */
+#define ATTRIBUTE               0x0F
+/* The video memory address. */
+#define VIDEO                   0xB8000
+
+#define SPACE			0x20
+
+#define MAX_VGA_BUF			(2 * ((COLUMNS * LINES) + COLUMNS))
+
+#define VGA_CTL_REG  0x3D4
+#define VGA_DATA_REG 0x3D5
+
+#define KEY_DEVICE    0x60
+#define KEY_PENDING   0x64
+
+/* Variables. */
+/* Save the X position. */
+static int csr_x;
+/* Save the Y position. */
+static int csr_y;
+/* Point to the video memory. */
+static volatile unsigned char *video;
+/* Attribute of a character */
+int attrib = ATTRIBUTE;
+
+/* Forward declarations. */
+static unsigned short *memsetw(unsigned short *dest, unsigned short val, size_t count);
+static void puts(unsigned char *str);
+static void move_csr(void);
+static void cls(void);
+static void cll(void);
+static void putchar (int c);
+
+/* Utility: set 16bit memory with 16bit value */
+static unsigned short *memsetw(unsigned short *dest, unsigned short val, size_t count)
+{
+    /* Same as memset, but this time, we're working with a 16-bit
+    *  'val' and dest pointer. Your code can be an exact copy of
+    *  the memset, provided that your local variables if any, are
+    *  unsigned short */
+    unsigned short *temp = (unsigned short *)dest;
+    for( ; count != 0; count--) *temp++ = val;
+    return dest;
+}
+
+/* Updates the hardware cursor: the little blinking line
+ *  on the screen under the last character pressed! */
+static void move_csr(void)
+{
+	unsigned pos;
+
+	/* The equation for finding the index in a linear
+	 *  chunk of memory can be represented by:
+	 *  Index = [(y * width) + x] */
+	pos = csr_y * COLUMNS + csr_x;
+
+	/* This sends a command to indicies 14 and 15 in the
+	 *  CRT Control Register of the VGA controller. These
+	 *  are the high and low bytes of the index that show
+	 *  where the hardware cursor is to be 'blinking'. To
+	 *  learn more, you should look up some VGA specific
+	 *  programming documents. A great start to graphics:
+	 *  http://www.brackeen.com/home/vga */
+	outb(VGA_CTL_REG, 14);
+	outb(VGA_DATA_REG, pos >> 8);
+	outb(VGA_CTL_REG, 15);
+	outb(VGA_DATA_REG, pos);
+}
+
+/* Clears the line from current y position */
+static void cll(void)
+{
+	/* Again, we need the 'short' that will be used to
+	 *  represent a space with color */
+	unsigned blank = SPACE | (attrib << 8);
+	/* Sets the entire screen to spaces in our current
+	 *  color */
+	memsetw ((unsigned short *)video + csr_y * COLUMNS + csr_x, blank, COLUMNS - csr_x);
+}
+
+
+/* Clears the screen */
+static void cls(void)
+{
+	unsigned blank;
+	int i;
+
+	/* Again, we need the 'short' that will be used to
+	 *  represent a space with color */
+	blank = SPACE | (attrib << 8);
+
+	/* Sets the entire screen to spaces in our current
+	 *  color */
+	for(i = 0; i < LINES; i++)
+		memsetw ((unsigned short *)video + i * COLUMNS, blank, COLUMNS);
+
+	/* Update out virtual cursor, and then move the
+	 *  hardware cursor */
+	csr_x = 0;
+	csr_y = 0;
+	move_csr();
+}
+
+/* Clear the screen and initialize VIDEO, XPOS and YPOS. */
+void
+vga_init (void)
+{
+	int i;
+
+	video = (unsigned char *) VIDEO;
+
+	csr_x = 0;
+	csr_y = 0;
+	cls();
+	printk_register_handler(vga_puts);
+}
+
+/* VIDEO - High address. */
+void
+vga_high_init (void)
+{
+	video = chal_pa2va(VIDEO);
+}
+
+/* Put the character C on the screen. */
+static void
+putchar (int c)
+{
+	if (c == '\n' || c == '\r')
+	{
+newline:
+		cll();
+		csr_x = 0;
+		csr_y++;
+		if (csr_y >= LINES)
+			//like rotation and not scrolling up!! 
+			csr_y = 0;
+		return;
+	}
+
+	*(video + (csr_x + csr_y * COLUMNS) * 2) = c & 0xFF;
+	*(video + (csr_x + csr_y * COLUMNS) * 2 + 1) = attrib;
+
+	csr_x++;
+	if (csr_x >= COLUMNS)
+		goto newline;
+}
+
+void
+vga_puts(const char *s)
+{
+	puts((unsigned char *)s);
+}
+
+/* Uses the above routine to output a string... */
+static void puts(unsigned char *text)
+{
+	size_t i;
+
+	cll();
+	for (i = 0; i < strnlen((const char*)text, STRLEN_MAX); i++)
+	{
+		putchar(text[i]);
+	}
+	move_csr();
+}
+
+
+void
+keyboard_handler(struct pt_regs *regs)
+{
+	u16_t scancode;
+
+	ack_irq(IRQ_KEYBOARD);
+
+	while(inb(KEY_PENDING) & 2) {
+		/* wait for keypress to be ready */
+	}
+	scancode = inb(KEY_DEVICE);
+	printk("Keyboard press: %d\n", scancode);
+}
+

--- a/src/platform/i386/vm.c
+++ b/src/platform/i386/vm.c
@@ -19,6 +19,12 @@ u32_t boot_comp_pgd[PAGE_SIZE/sizeof(u32_t)] PAGE_ALIGNED = {
 };
 
 void
+double_fault_handler(struct pt_regs *regs)
+{
+	die("DOUBLE FAULT..\n");
+}
+
+void
 page_fault_handler(struct pt_regs *regs)
 {
 	u32_t fault_addr, errcode = 0, eip = 0;


### PR DESCRIPTION
Major changes:
1. memset on thread struct.
2. parsing mod->cmdline for bare-metal.

Other changes: 
1. Added 'FOREVER' in khalt() which is useful in debugging especially on Bare-metal.
2. platform/i386/vga.c is picked up from online sources (may not comply with Composite style guide). 
3. Double fault stub added.