### PR TITLE
Build and run Composite from anywhere

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ src/PLATFORM
 modules.order
 .depend
 *.img
+transfer/

--- a/src/Makefile
+++ b/src/Makefile
@@ -40,6 +40,7 @@ clean:
 
 distclean: clean
 	$(MAKE) $(MAKEFLAGS) -C components distclean	
+	rm -f `pwd`/../transfer/*
 
 init:
 	$(MAKE) $(MAKEFLAGS) -C components init
@@ -52,8 +53,9 @@ config-gen:
 	@cat /proc/cpuinfo | grep "model name" -m 1 | sed 's/.*\([0-9]\.[0-9]*\).*/\#define CPU_GHZ \1/' > ./kernel/include/shared/cpu_ghz.h
 	@if [ -z "`cat /proc/cpuinfo | grep \"physical id\"`" ]; then echo "#define NUM_CPU_SOCKETS 1" >> ./kernel/include/shared/cpu_ghz.h; else cat /proc/cpuinfo | grep "physical id" | sort | uniq | wc -l | sed 's/.*\([0-9]\).*/\#define NUM_CPU_SOCKETS \1/' >> ./kernel/include/shared/cpu_ghz.h; fi
 	@pwd | sed 's/\(\/[a-zA-Z0-9]*\/[a-zA-Z0-9]*\/\).*/HOME_DIR=\1/' > Makefile.cosconfig
-	@echo "CODE_DIR=\$$(HOME_DIR)/research/" >> Makefile.cosconfig
-	@echo "TRANS_DIR=\$$(HOME_DIR)/transfer/" >> Makefile.cosconfig
+	@echo "CODE_DIR=`pwd`" >> Makefile.cosconfig
+	@echo "TRANS_DIR=\$$(CODE_DIR)/../transfer" >> Makefile.cosconfig
+	mkdir -p `pwd`/../transfer
 	@echo "LDIR=\$$(CODE_DIR)/linux-2.6.36/" >> Makefile.cosconfig
 	@echo "TEST_DIR=/root/experiments/" >> Makefile.cosconfig
 

--- a/src/Makefile.src
+++ b/src/Makefile.src
@@ -1,7 +1,7 @@
 include Makefile.cosconfig
 
 # the directory this file is in
-TOP_DIR=$(CODE_DIR)/composite/src/
+TOP_DIR=$(CODE_DIR)/
 # the directory the linux source is in
 #LDIR=$(CODE_DIR)/linux-2.6.33/
 # the directory all objects will be copied to when they are ready for

--- a/src/components/implementation/Makefile.subsubdir
+++ b/src/components/implementation/Makefile.subsubdir
@@ -49,7 +49,7 @@ SOURCE_DEPENDENCIES=$(SOURCES:%.c=%.d)
 
 COMP_LD_SCRIPT=$(IMPLDIR)/comp.ld
 
-FNDEP_DIR=../../../cidl
+FNDEP_DIR=$(CDIR)/cidl
 FNDEP_GEN=$(FNDEP_DIR)/comp_undef.py
 FNDEP_VERIFY=$(FNDEP_DIR)/verify_completeness.py
 IFEXP_GEN=$(FNDEP_DIR)/exp_ifs.py

--- a/src/components/lib/posix/Makefile
+++ b/src/components/lib/posix/Makefile
@@ -1,4 +1,4 @@
-CC=$(HOME)/research/composite/src/components/lib/dietlibc-0.29/bin-i386/diet gcc
+CC=$(CDIR)/lib/dietlibc-0.29/bin-i386/diet gcc
 CFLAGS=-Wall -fno-stack-protector -I../../include -I../../../kernel/include -I../../../kernel/include/shared -I../../interface/cbuf_c -I../../interface/cbufp -I../../interface/evt
 
 .PHONY: all


### PR DESCRIPTION
### Summary of this PR

Modified Makefiles to allow Composite to be compiled and run from anywhere.
Note:
1. transfer directory required for copying composite objects and binaries will be created under `Composite/` directory.
2. For these changes to work, it's best to re-build Composite ( a. `make distclean` -> b. `make config-i386` -> c. `make init` -> d. `make` -> e. `make cp`).

### Code Quality

As part of this pull request, I've considered the following:

Style:

- [x] Comments adhere to the Style Guide (SG)
- [x] Spacing adhere's to the SG 
- [x] Naming adhere's to the SG
- [x] All other aspects of the SG are adhered to, or exceptions are justified in this pull request

Code Craftsmanship:

- [x] I've made an attempt to remove all redundant code
- [x] I've considered ways in which my changes might impact existing code, and cleaned it up
- [x] I've formatted the code in an effort to make it easier to read (proper error handling, function use, etc...)
- [x] I've commented appropriately where code is tricky
- [x] I agree that there is no "throw-away" code, and that code in this PR is of high quality 
