### PR TITLE
bug fix: remove redundant liveness_tbl, undo refcnt and fix __captbl_…

### DIFF
--- a/src/kernel/include/captbl.h
+++ b/src/kernel/include/captbl.h
@@ -156,7 +156,7 @@ __captbl_getleaf(struct ert_intern *a, void *accum)
 	if (likely(h->size == __captbl_cap2sz(CAP_SINV))) {
 		c   = (struct cap_header *)CT_MSK(a, __captbl_cap2sz(CAP_SINV) + CAP_SZ_OFF);
 		off = (struct cap_min*)c - (struct cap_min*)h; /* ptr math */
-		if (likely(h->amap & off)) return c;
+		if (likely(h->amap & (1<<off))) return c;
 	}
 
 	/*

--- a/src/kernel/liveness_tbl.c
+++ b/src/kernel/liveness_tbl.c
@@ -1,7 +1,5 @@
 #include "include/liveness_tbl.h"
 
-struct liveness_entry __liveness_tbl[LTBL_ENTS];
-
 void
 ltbl_init(void)
 {


### PR DESCRIPTION
### Summary of this PR

bug fix: remove redundant liveness_tbl, undo refcnt and fix __captbl_getleaf

### Code Quality

As part of this pull request, I've considered the following:

Style:

- [x] Comments adhere to the Style Guide (SG)
- [x] Spacing adhere's to the SG 
- [x] Naming adhere's to the SG
- [x] All other aspects of the SG are adhered to, or exceptions are justified in this pull request

Code Craftsmanship:

- [x] I've made an attempt to remove all redundant code
- [x] I've considered ways in which my changes might impact existing code, and cleaned it up
- [x] I've formatted the code in an effort to make it easier to read (proper error handling, function use, etc...)
- [x] I've commented appropriately where code is tricky
- [x] I agree that there is no "throw-away" code, and that code in this PR is of high quality
