### PR TITLE
use separate page tables to manage different type of memory

### DIFF
--- a/src/components/implementation/tests/micro_booter/micro_booter.c
+++ b/src/components/implementation/tests/micro_booter/micro_booter.c
@@ -568,7 +568,7 @@ term_fn(void *d)
 void
 cos_init(void)
 {
-	cos_meminfo_init(&booter_info.mi, BOOT_MEM_KM_BASE, COS_MEM_KERN_PA_SZ);
+	cos_meminfo_init(&booter_info.local_mi, BOOT_MEM_KM_BASE, COS_MEM_KERN_PA_SZ, BOOT_CAPTBL_SELF_LOCAL_PT);
 	cos_compinfo_init(&booter_info, BOOT_CAPTBL_SELF_PT, BOOT_CAPTBL_SELF_CT, BOOT_CAPTBL_SELF_COMP,
 			  (vaddr_t)cos_get_heap_ptr(), BOOT_CAPTBL_FREE, &booter_info);
 

--- a/src/components/include/cos_kernel_api.h
+++ b/src/components/include/cos_kernel_api.h
@@ -25,6 +25,7 @@ typedef capid_t hwcap_t;
 struct cos_meminfo {
 	vaddr_t untyped_ptr,      umem_ptr,      kmem_ptr;
 	vaddr_t untyped_frontier, umem_frontier, kmem_frontier;
+	capid_t pgtbl_cap;
 };
 
 /* Component captbl/pgtbl allocation information */
@@ -39,16 +40,16 @@ struct cos_compinfo {
 	vaddr_t vas_frontier, vasrange_frontier;
 	/* the source of memory */
 	struct cos_compinfo *memsrc; /* might be self-referential */
-	struct cos_meminfo mi;	     /* only populated for the component with real memory */
+	struct cos_meminfo local_mi;	     /* only populated for the component with real memory */
 };
 
-void cos_compinfo_init(struct cos_compinfo *ci, captblcap_t pgtbl_cap, pgtblcap_t captbl_cap, compcap_t comp_cap, vaddr_t heap_ptr, capid_t cap_frontier, struct cos_compinfo *ci_resources);
+void cos_compinfo_init(struct cos_compinfo *ci, pgtblcap_t pgtbl_cap, captblcap_t captbl_cap, compcap_t comp_cap, vaddr_t heap_ptr, capid_t cap_frontier, struct cos_compinfo *ci_resources);
 /*
  * This only needs be called on compinfos that are managing resources
  * (i.e. likely only one).  All of the capabilities will be relative
  * to this component's captbls.
  */
-void cos_meminfo_init(struct cos_meminfo *mi, vaddr_t untyped_ptr, unsigned long untyped_sz);
+void cos_meminfo_init(struct cos_meminfo *mi, vaddr_t untyped_ptr, unsigned long untyped_sz, pgtblcap_t pgtbl_cap);
 
 /*
  * This uses the next three functions to allocate a new component and

--- a/src/components/lib/cos_kernel_api.c
+++ b/src/components/lib/cos_kernel_api.c
@@ -29,10 +29,11 @@ printd(char *fmt, ...)
 #endif
 
 void
-cos_meminfo_init(struct cos_meminfo *mi, vaddr_t untyped_ptr, unsigned long untyped_sz)
+cos_meminfo_init(struct cos_meminfo *mi, vaddr_t untyped_ptr, unsigned long untyped_sz, pgtblcap_t pgtbl_cap)
 {
 	mi->untyped_ptr = mi->umem_ptr = mi->kmem_ptr = mi->umem_frontier = mi->kmem_frontier = untyped_ptr;
 	mi->untyped_frontier = untyped_ptr + untyped_sz;
+	mi->pgtbl_cap = pgtbl_cap;
 }
 
 static inline struct cos_compinfo *
@@ -40,7 +41,7 @@ __compinfo_metacap(struct cos_compinfo *ci)
 { return ci->memsrc; }
 
 void
-cos_compinfo_init(struct cos_compinfo *ci, captblcap_t pgtbl_cap, pgtblcap_t captbl_cap,
+cos_compinfo_init(struct cos_compinfo *ci, pgtblcap_t pgtbl_cap, captblcap_t captbl_cap,
 		  compcap_t comp_cap, vaddr_t heap_ptr, capid_t cap_frontier,
 		  struct cos_compinfo *ci_resources)
 {
@@ -90,17 +91,17 @@ __mem_bump_alloc(struct cos_compinfo *__ci, int km)
 	assert(ci && ci == __compinfo_metacap(__ci));
 
 	if (km) {
-		ptr      = &ci->mi.kmem_ptr;
-		frontier = &ci->mi.kmem_frontier;
+		ptr      = &ci->local_mi.kmem_ptr;
+		frontier = &ci->local_mi.kmem_frontier;
 	} else {
-		ptr      = &ci->mi.umem_ptr;
-		frontier = &ci->mi.umem_frontier;
+		ptr      = &ci->local_mi.umem_ptr;
+		frontier = &ci->local_mi.umem_frontier;
 	}
 	if (*ptr == *frontier) {
 		/* TODO: expand frontier if introspection says there is more memory */
-		if (ci->mi.untyped_ptr == ci->mi.untyped_frontier) return 0;
-		ret                 = ci->mi.untyped_ptr;
-		ci->mi.untyped_ptr += RETYPE_MEM_SIZE; /* TODO: atomic */
+		if (ci->local_mi.untyped_ptr == ci->local_mi.untyped_frontier) return 0;
+		ret                 = ci->local_mi.untyped_ptr;
+		ci->local_mi.untyped_ptr += RETYPE_MEM_SIZE; /* TODO: atomic */
 		*ptr                = ret;
 		*frontier           = ret + RETYPE_MEM_SIZE;
 	}
@@ -109,7 +110,7 @@ __mem_bump_alloc(struct cos_compinfo *__ci, int km)
 		/* are we dealing with a kernel memory allocation? */
 		syscall_op_t op = km ? CAPTBL_OP_MEM_RETYPE2KERN : CAPTBL_OP_MEM_RETYPE2USER;
 
-		if (call_cap_op(ci->pgtbl_cap, op, ret, 0, 0, 0)) return 0;
+		if (call_cap_op(ci->local_mi.pgtbl_cap, op, ret, 0, 0, 0)) return 0;
 	}
 
 	*ptr += PAGE_SIZE;
@@ -200,7 +201,7 @@ __capid_captbl_check_expand(struct cos_compinfo *ci)
 
 	printd("__capid_captbl_check_expand->pre-captblactivate (%d)\n", CAPTBL_OP_CAPTBLACTIVATE);
 	/* captbl internal node allocated with the resource provider's captbls */
-	if (call_cap_op(meta->captbl_cap, CAPTBL_OP_CAPTBLACTIVATE, captblcap, meta->pgtbl_cap, kmem, 1)) {
+	if (call_cap_op(meta->captbl_cap, CAPTBL_OP_CAPTBLACTIVATE, captblcap, meta->local_mi.pgtbl_cap, kmem, 1)) {
 		assert(0); /* race condition? */
 		return -1;
 	}
@@ -298,7 +299,7 @@ __page_bump_valloc(struct cos_compinfo *ci)
 
 		/* PTE */
 		if (call_cap_op(meta->captbl_cap, CAPTBL_OP_PGTBLACTIVATE,
-				pte_cap, meta->pgtbl_cap, ptemem_cap, 1)) {
+				pte_cap, meta->local_mi.pgtbl_cap, ptemem_cap, 1)) {
 			assert(0); /* race? */
 			return 0;
 		}
@@ -338,7 +339,7 @@ __page_bump_alloc(struct cos_compinfo *ci)
 	if (!umem) return 0;
 
 	/* Actually map in the memory. FIXME: cleanup! */
-	if (call_cap_op(meta->pgtbl_cap, CAPTBL_OP_MEMACTIVATE, umem,
+	if (call_cap_op(meta->local_mi.pgtbl_cap, CAPTBL_OP_MEMACTIVATE, umem,
 			ci->pgtbl_cap, heap_vaddr, 0)) {
 		assert(0);
 		return 0;
@@ -386,7 +387,7 @@ __cos_thd_alloc(struct cos_compinfo *ci, compcap_t comp, int init_data)
 	if (__alloc_mem_cap(ci, CAP_THD, &kmem, &cap)) return 0;
 	assert((size_t)init_data < sizeof(u16_t)*8);
 	/* TODO: Add cap size checking */
-	if (call_cap_op(ci->captbl_cap, CAPTBL_OP_THDACTIVATE, (init_data << 16) | cap, ci->pgtbl_cap, kmem, comp)) BUG();
+	if (call_cap_op(ci->captbl_cap, CAPTBL_OP_THDACTIVATE, (init_data << 16) | cap, __compinfo_metacap(ci)->local_mi.pgtbl_cap, kmem, comp)) BUG();
 
 	return cap;
 }
@@ -421,7 +422,7 @@ cos_captbl_alloc(struct cos_compinfo *ci)
 	assert(ci);
 
 	if (__alloc_mem_cap(ci, CAP_CAPTBL, &kmem, &cap)) return 0;
-	if (call_cap_op(ci->captbl_cap, CAPTBL_OP_CAPTBLACTIVATE, cap, ci->pgtbl_cap, kmem, 0)) BUG();
+	if (call_cap_op(ci->captbl_cap, CAPTBL_OP_CAPTBLACTIVATE, cap, __compinfo_metacap(ci)->local_mi.pgtbl_cap, kmem, 0)) BUG();
 
 	return cap;
 }
@@ -437,7 +438,7 @@ cos_pgtbl_alloc(struct cos_compinfo *ci)
 	assert(ci);
 
 	if (__alloc_mem_cap(ci, CAP_PGTBL, &kmem, &cap)) return 0;
-	if (call_cap_op(ci->captbl_cap, CAPTBL_OP_PGTBLACTIVATE, cap, ci->pgtbl_cap, kmem, 0))  BUG();
+	if (call_cap_op(ci->captbl_cap, CAPTBL_OP_PGTBLACTIVATE, cap, __compinfo_metacap(ci)->local_mi.pgtbl_cap, kmem, 0))  BUG();
 
 	return cap;
 }
@@ -647,7 +648,7 @@ cos_tcap_alloc(struct cos_compinfo *ci, tcap_prio_t prio)
 
 	if (__alloc_mem_cap(ci, CAP_TCAP, &kmem, &cap)) return 0;
 	/* TODO: Add cap size checking */
-	if (call_cap_op(ci->captbl_cap, CAPTBL_OP_TCAP_ACTIVATE, (cap << 16) | ci->pgtbl_cap, kmem, prio_hi, prio_lo)) BUG();
+	if (call_cap_op(ci->captbl_cap, CAPTBL_OP_TCAP_ACTIVATE, (cap << 16) | __compinfo_metacap(ci)->local_mi.pgtbl_cap, kmem, prio_hi, prio_lo)) BUG();
 
 	return cap;
 }

--- a/src/kernel/include/shared/cos_types.h
+++ b/src/kernel/include/shared/cos_types.h
@@ -226,6 +226,7 @@ static inline unsigned long captbl_idsize(cap_t c)
  * 16-17 = km pte
  * 18-19 = comp0 captbl,
  * 20-21 = comp0 pgtbl root,
+ * 22-23 = local memory pgtbl root
  * 24-27 = comp0 component,
  * 28~(20+2*NCPU) = per core alpha thd
  *
@@ -235,16 +236,17 @@ static inline unsigned long captbl_idsize(cap_t c)
  * 2GB-> = system physical memory
  */
 enum {
-	BOOT_CAPTBL_SRET       = 0,
-	BOOT_CAPTBL_SELF_CT    = 4,
-	BOOT_CAPTBL_SELF_PT    = 6,
-	BOOT_CAPTBL_SELF_COMP  = 8,
-	BOOT_CAPTBL_BOOTVM_PTE = 12,
-	BOOT_CAPTBL_PHYSM_PTE  = 14,
-	BOOT_CAPTBL_KM_PTE     = 16,
+	BOOT_CAPTBL_SRET          = 0,
+	BOOT_CAPTBL_SELF_CT       = 4,
+	BOOT_CAPTBL_SELF_PT       = 6,
+	BOOT_CAPTBL_SELF_COMP     = 8,
+	BOOT_CAPTBL_BOOTVM_PTE    = 12,
+	BOOT_CAPTBL_SELF_LOCAL_PT = 14,
+	BOOT_CAPTBL_PHYSM_PTE     = 16,
+	BOOT_CAPTBL_KM_PTE        = 18,
 
-	BOOT_CAPTBL_COMP0_CT           = 18,
-	BOOT_CAPTBL_COMP0_PT           = 20,
+	BOOT_CAPTBL_COMP0_CT           = 20,
+	BOOT_CAPTBL_COMP0_PT           = 22,
 	BOOT_CAPTBL_COMP0_COMP         = 24,
 	BOOT_CAPTBL_SELF_INITTHD_BASE  = 28,
 	BOOT_CAPTBL_SELF_INITTCAP_BASE = BOOT_CAPTBL_SELF_INITTHD_BASE + NUM_CPU_COS*CAP16B_IDSZ,

--- a/src/platform/i386/boot_comp.c
+++ b/src/platform/i386/boot_comp.c
@@ -15,14 +15,17 @@ extern u8_t *boot_comp_pgd;
 int boot_nptes(unsigned int sz) { return round_up_to_pow2(sz, PGD_RANGE)/PGD_RANGE; }
 
 int
-boot_pgtbl_mappings_add(struct captbl *ct, pgtbl_t pgtbl, capid_t ptecap, const char *label,
+boot_pgtbl_mappings_add(struct captbl *ct, capid_t pgdcap, capid_t ptecap, const char *label,
 			void *kern_vaddr, unsigned long user_vaddr, unsigned int range, int uvm)
 {
 	int ret;
 	u8_t *ptes;
 	unsigned int nptes = 0, i;
-	struct cap_pgtbl *pte_cap;
+	struct cap_pgtbl *pte_cap, *pgd_cap;
+	pgtbl_t pgtbl;
 
+	pgd_cap = (struct cap_pgtbl*)captbl_lkup(ct, pgdcap);
+	pgtbl = (pgtbl_t)pgd_cap->pgtbl;
 	nptes = boot_nptes(range);
 	ptes = mem_boot_alloc(nptes);
 	assert(ptes);
@@ -53,7 +56,7 @@ boot_pgtbl_mappings_add(struct captbl *ct, pgtbl_t pgtbl, capid_t ptecap, const 
 		pte_cap->pgtbl = (pgtbl_t)p;
 
 		/* hook the pte into the boot component's page tables */
-		ret = cap_cons(ct, BOOT_CAPTBL_SELF_PT, ptecap, (capid_t)(user_vaddr + i*PGD_RANGE));
+		ret = cap_cons(ct, pgdcap, ptecap, (capid_t)(user_vaddr + i*PGD_RANGE));
 		assert(!ret);
 	}
 
@@ -112,7 +115,7 @@ kern_boot_comp(void)
         struct captbl *ct;
         unsigned int i;
 	u8_t *boot_comp_captbl;
-	pgtbl_t pgtbl = (pgtbl_t)chal_va2pa(&boot_comp_pgd);
+	pgtbl_t pgtbl = (pgtbl_t)chal_va2pa(&boot_comp_pgd), local_pgd;
 	void *thd_mem, *tcap_mem;
 	u32_t hw_bitmap = 0xFFFFFFFF;
 
@@ -144,7 +147,7 @@ kern_boot_comp(void)
 
 	printk("\tCapability table and page-table created.\n");
 
-	ret = boot_pgtbl_mappings_add(ct, pgtbl, BOOT_CAPTBL_BOOTVM_PTE, "booter VM", mem_bootc_start(),
+	ret = boot_pgtbl_mappings_add(ct, BOOT_CAPTBL_SELF_PT, BOOT_CAPTBL_BOOTVM_PTE, "booter VM", mem_bootc_start(),
 				      (unsigned long)mem_bootc_vaddr(), mem_bootc_end() - mem_bootc_start(), 1);
 	assert(ret == 0);
 
@@ -155,8 +158,10 @@ kern_boot_comp(void)
 	 * Need to account for the pages that will be allocated as
 	 * PTEs
 	 */
+	local_pgd = (pgtbl_t)chal_va2pa(mem_boot_alloc(1));
+	if (pgtbl_activate(ct, BOOT_CAPTBL_SELF_CT, BOOT_CAPTBL_SELF_LOCAL_PT, local_pgd, 0)) assert(0);
 	nkmemptes = boot_nptes(mem_utmem_end() - mem_boot_end());
-	ret = boot_pgtbl_mappings_add(ct, pgtbl, BOOT_CAPTBL_KM_PTE, "untyped memory", mem_boot_nalloc_end(nkmemptes),
+	ret = boot_pgtbl_mappings_add(ct, BOOT_CAPTBL_SELF_LOCAL_PT, BOOT_CAPTBL_KM_PTE, "untyped memory", mem_boot_nalloc_end(nkmemptes),
 				      BOOT_MEM_KM_BASE, mem_utmem_end() - mem_boot_nalloc_end(nkmemptes), 0);
 	assert(ret == 0);
 	/* Shut off further bump allocations */


### PR DESCRIPTION
### Summary of this PR

support multiple page tables to manage different type of memory.
current implementation uses a separate page tables to manage local memory.
modify cos_meminfo struct to include a cap to page table which provides memory.
some explanation to the page table capability.
meta (struct cos_compinfo \*memsrc) maintains the manager component's information, the pgtbl_cap in meta is the capability to the manager's own page table.
The pgtbl_cap in **local_mi** is the capability to a page table which tracks memory resource, currently it tracks all local memory.
**ci** maintains the information of a random client component. The pgtbl_cap in **ci** a capability to client's page table, and that capability is **within manager's (meta) capability table.**
The same logic applies to the captbl_cap

### Code Quality

As part of this pull request, I've considered the following:

Style:

- [x] Comments adhere to the Style Guide (SG)
- [x] Spacing adhere's to the SG 
- [x] Naming adhere's to the SG
- [x] All other aspects of the SG are adhered to, or exceptions are justified in this pull request

Code Craftsmanship:

- [x] I've made an attempt to remove all redundant code
- [x] I've considered ways in which my changes might impact existing code, and cleaned it up
- [x] I've formatted the code in an effort to make it easier to read (proper error handling, function use, etc...)
- [x] I've commented appropriately where code is tricky
- [x] I agree that there is no "throw-away" code, and that code in this PR is of high quality

