### PR TITLE
use separate page table to manage untyped memory

### DIFF
--- a/src/components/implementation/tests/micro_booter/micro_booter.c
+++ b/src/components/implementation/tests/micro_booter/micro_booter.c
@@ -568,7 +568,7 @@ term_fn(void *d)
 void
 cos_init(void)
 {
-	cos_meminfo_init(&booter_info.mi, BOOT_MEM_KM_BASE, COS_MEM_KERN_PA_SZ);
+	cos_meminfo_init(&booter_info.mi, BOOT_MEM_KM_BASE, COS_MEM_KERN_PA_SZ, BOOT_CAPTBL_SELF_UNTYPED_PT);
 	cos_compinfo_init(&booter_info, BOOT_CAPTBL_SELF_PT, BOOT_CAPTBL_SELF_CT, BOOT_CAPTBL_SELF_COMP,
 			  (vaddr_t)cos_get_heap_ptr(), BOOT_CAPTBL_FREE, &booter_info);
 

--- a/src/components/include/cos_kernel_api.h
+++ b/src/components/include/cos_kernel_api.h
@@ -25,6 +25,7 @@ typedef capid_t hwcap_t;
 struct cos_meminfo {
 	vaddr_t untyped_ptr,      umem_ptr,      kmem_ptr;
 	vaddr_t untyped_frontier, umem_frontier, kmem_frontier;
+	pgtblcap_t pgtbl_cap;
 };
 
 /* Component captbl/pgtbl allocation information */
@@ -42,13 +43,13 @@ struct cos_compinfo {
 	struct cos_meminfo mi;	     /* only populated for the component with real memory */
 };
 
-void cos_compinfo_init(struct cos_compinfo *ci, captblcap_t pgtbl_cap, pgtblcap_t captbl_cap, compcap_t comp_cap, vaddr_t heap_ptr, capid_t cap_frontier, struct cos_compinfo *ci_resources);
+void cos_compinfo_init(struct cos_compinfo *ci, pgtblcap_t pgtbl_cap, captblcap_t captbl_cap, compcap_t comp_cap, vaddr_t heap_ptr, capid_t cap_frontier, struct cos_compinfo *ci_resources);
 /*
  * This only needs be called on compinfos that are managing resources
  * (i.e. likely only one).  All of the capabilities will be relative
  * to this component's captbls.
  */
-void cos_meminfo_init(struct cos_meminfo *mi, vaddr_t untyped_ptr, unsigned long untyped_sz);
+void cos_meminfo_init(struct cos_meminfo *mi, vaddr_t untyped_ptr, unsigned long untyped_sz, pgtblcap_t pgtbl_cap);
 
 /*
  * This uses the next three functions to allocate a new component and

--- a/src/kernel/include/shared/cos_types.h
+++ b/src/kernel/include/shared/cos_types.h
@@ -222,10 +222,11 @@ static inline unsigned long captbl_idsize(cap_t c)
  * 6-7 = our pgtbl root,
  * 8-11 = our component,
  * 12-13 = vm pte for booter
- * 14-15 = vm pte for physical memory
- * 16-17 = km pte
- * 18-19 = comp0 captbl,
- * 20-21 = comp0 pgtbl root,
+ * 14-15 = untyped memory pgtbl root,
+ * 16-17 = vm pte for physical memory,
+ * 18-19 = km pte,
+ * 20-21 = comp0 captbl,
+ * 22-23 = comp0 pgtbl root,
  * 24-27 = comp0 component,
  * 28~(20+2*NCPU) = per core alpha thd
  *
@@ -235,16 +236,17 @@ static inline unsigned long captbl_idsize(cap_t c)
  * 2GB-> = system physical memory
  */
 enum {
-	BOOT_CAPTBL_SRET       = 0,
-	BOOT_CAPTBL_SELF_CT    = 4,
-	BOOT_CAPTBL_SELF_PT    = 6,
-	BOOT_CAPTBL_SELF_COMP  = 8,
-	BOOT_CAPTBL_BOOTVM_PTE = 12,
-	BOOT_CAPTBL_PHYSM_PTE  = 14,
-	BOOT_CAPTBL_KM_PTE     = 16,
+	BOOT_CAPTBL_SRET            = 0,
+	BOOT_CAPTBL_SELF_CT         = 4,
+	BOOT_CAPTBL_SELF_PT         = 6,
+	BOOT_CAPTBL_SELF_COMP       = 8,
+	BOOT_CAPTBL_BOOTVM_PTE      = 12,
+	BOOT_CAPTBL_SELF_UNTYPED_PT = 14,
+	BOOT_CAPTBL_PHYSM_PTE       = 16,
+	BOOT_CAPTBL_KM_PTE          = 18,
 
-	BOOT_CAPTBL_COMP0_CT           = 18,
-	BOOT_CAPTBL_COMP0_PT           = 20,
+	BOOT_CAPTBL_COMP0_CT           = 20,
+	BOOT_CAPTBL_COMP0_PT           = 22,
 	BOOT_CAPTBL_COMP0_COMP         = 24,
 	BOOT_CAPTBL_SELF_INITTHD_BASE  = 28,
 	BOOT_CAPTBL_SELF_INITTCAP_BASE = BOOT_CAPTBL_SELF_INITTHD_BASE + NUM_CPU_COS*CAP16B_IDSZ,
@@ -257,7 +259,7 @@ enum {
 
 enum {
 	BOOT_MEM_VM_BASE = (COS_MEM_COMP_START_VA + (1<<22)), /* @ 1G + 8M */
-	BOOT_MEM_KM_BASE = 0x60000000, /* kernel memory @ 1.5 GB */
+	BOOT_MEM_KM_BASE = PAGE_SIZE, /* kernel memory @ first page, not at address 0 to avoid NULL */
 	BOOT_MEM_PM_BASE = 0x80000000, /* user memory @ 2 GB */
 };
 

--- a/src/platform/i386/boot_comp.c
+++ b/src/platform/i386/boot_comp.c
@@ -15,14 +15,18 @@ extern u8_t *boot_comp_pgd;
 int boot_nptes(unsigned int sz) { return round_up_to_pow2(sz, PGD_RANGE)/PGD_RANGE; }
 
 int
-boot_pgtbl_mappings_add(struct captbl *ct, pgtbl_t pgtbl, capid_t ptecap, const char *label,
+boot_pgtbl_mappings_add(struct captbl *ct, capid_t pgdcap, capid_t ptecap, const char *label,
 			void *kern_vaddr, unsigned long user_vaddr, unsigned int range, int uvm)
 {
 	int ret;
 	u8_t *ptes;
 	unsigned int nptes = 0, i;
-	struct cap_pgtbl *pte_cap;
+	struct cap_pgtbl *pte_cap, *pgd_cap;
+	pgtbl_t pgtbl;
 
+	pgd_cap = (struct cap_pgtbl*)captbl_lkup(ct, pgdcap);
+	if (!pgd_cap || !CAP_TYPECHK(pgd_cap, CAP_PGTBL)) assert(0);
+	pgtbl = (pgtbl_t)pgd_cap->pgtbl;
 	nptes = boot_nptes(range);
 	ptes = mem_boot_alloc(nptes);
 	assert(ptes);
@@ -53,7 +57,7 @@ boot_pgtbl_mappings_add(struct captbl *ct, pgtbl_t pgtbl, capid_t ptecap, const 
 		pte_cap->pgtbl = (pgtbl_t)p;
 
 		/* hook the pte into the boot component's page tables */
-		ret = cap_cons(ct, BOOT_CAPTBL_SELF_PT, ptecap, (capid_t)(user_vaddr + i*PGD_RANGE));
+		ret = cap_cons(ct, pgdcap, ptecap, (capid_t)(user_vaddr + i*PGD_RANGE));
 		assert(!ret);
 	}
 
@@ -112,7 +116,7 @@ kern_boot_comp(void)
         struct captbl *ct;
         unsigned int i;
 	u8_t *boot_comp_captbl;
-	pgtbl_t pgtbl = (pgtbl_t)chal_va2pa(&boot_comp_pgd);
+	pgtbl_t pgtbl = (pgtbl_t)chal_va2pa(&boot_comp_pgd), untyped_pgd;
 	void *thd_mem, *tcap_mem;
 	u32_t hw_bitmap = 0xFFFFFFFF;
 
@@ -144,7 +148,7 @@ kern_boot_comp(void)
 
 	printk("\tCapability table and page-table created.\n");
 
-	ret = boot_pgtbl_mappings_add(ct, pgtbl, BOOT_CAPTBL_BOOTVM_PTE, "booter VM", mem_bootc_start(),
+	ret = boot_pgtbl_mappings_add(ct, BOOT_CAPTBL_SELF_PT, BOOT_CAPTBL_BOOTVM_PTE, "booter VM", mem_bootc_start(),
 				      (unsigned long)mem_bootc_vaddr(), mem_bootc_end() - mem_bootc_start(), 1);
 	assert(ret == 0);
 
@@ -155,8 +159,10 @@ kern_boot_comp(void)
 	 * Need to account for the pages that will be allocated as
 	 * PTEs
 	 */
+	untyped_pgd = (pgtbl_t)chal_va2pa(mem_boot_alloc(1));
+	if (pgtbl_activate(ct, BOOT_CAPTBL_SELF_CT, BOOT_CAPTBL_SELF_UNTYPED_PT, untyped_pgd, 0)) assert(0);
 	nkmemptes = boot_nptes(mem_utmem_end() - mem_boot_end());
-	ret = boot_pgtbl_mappings_add(ct, pgtbl, BOOT_CAPTBL_KM_PTE, "untyped memory", mem_boot_nalloc_end(nkmemptes),
+	ret = boot_pgtbl_mappings_add(ct, BOOT_CAPTBL_SELF_UNTYPED_PT, BOOT_CAPTBL_KM_PTE, "untyped memory", mem_boot_nalloc_end(nkmemptes),
 				      BOOT_MEM_KM_BASE, mem_utmem_end() - mem_boot_nalloc_end(nkmemptes), 0);
 	assert(ret == 0);
 	/* Shut off further bump allocations */


### PR DESCRIPTION
### Summary of this PR

put all the untyped memory into a separate page table instead of in the booter's PT.
technique details:
kernel:
modify boot_comp.c 
create a new page table at the offset BOOT_CAPTBL_SELF_UNTYPED_PT.
map all untyped memory into that page table starting from the first page. Starting address 0 cause allocation to return NULL, which mistakes the allocation is fail.
modify boot_pgtbl_mappings_add function to parameterize which pgtbl to use, changing its argument from page table physical address to page table capability.
Mircor_booter:
 expand cos_meminfo struct to include a cap to page table which provides memory.
 fix some mistyping.

some explanation to the page table capability.
meta (struct cos_compinfo *memsrc) maintains the manager component's information, the pgtbl_cap in meta is the capability to the manager's own page table.
The pgtbl_cap in local_mi is the capability to a page table which tracks memory resource, currently it tracks all local memory.
ci maintains the information of a random client component. The pgtbl_cap in ci a capability to client's page table, and that capability is within manager's (meta) capability table.
The same logic applies to the captbl_cap
### Code Quality

As part of this pull request, I've considered the following:

Style:

- [x] Comments adhere to the Style Guide (SG)
- [x] Spacing adhere's to the SG 
- [x] Naming adhere's to the SG
- [x] All other aspects of the SG are adhered to, or exceptions are justified in this pull request

Code Craftsmanship:

- [x] I've made an attempt to remove all redundant code
- [x] I've considered ways in which my changes might impact existing code, and cleaned it up
- [x] I've formatted the code in an effort to make it easier to read (proper error handling, function use, etc...)
- [x] I've commented appropriately where code is tricky
- [x] I agree that there is no "throw-away" code, and that code in this PR is of high quality

