### PR TITLE
Adds vkernel feature, fix for copying Kernel PTEs to booter's pgtbl, other minor cleanups

### DIFF
--- a/src/components/implementation/mem_mgr/parsec/mem_man_parsec.c
+++ b/src/components/implementation/mem_mgr/parsec/mem_man_parsec.c
@@ -662,7 +662,7 @@ frame_init(void)
 	}
 
 	/* Detecting all the frames. */
-	n_pmem = frame_boot(BOOT_MEM_PM_BASE, &frame_ns);
+	n_pmem = frame_boot(BOOT_MEM_KM_BASE, &frame_ns);
 
 	return;
 }

--- a/src/components/implementation/no_interface/llboot/boot_deps.h
+++ b/src/components/implementation/no_interface/llboot/boot_deps.h
@@ -249,7 +249,7 @@ vaddr_t get_kmem_cap(void) {
 	return ret;
 }
 
-static vaddr_t pmem_heap = BOOT_MEM_PM_BASE;
+static vaddr_t pmem_heap = BOOT_MEM_KM_BASE;
 
 /* Only called by the init core. No lock / atomic op required. */
 vaddr_t get_pmem_cap(void) {
@@ -542,7 +542,7 @@ boot_comp_mm_init(void)
 	n_frames = 0;
 	/* Grant the rest of the memory to the mem_mgr component. */
 	while ((memcap = get_pmem_cap())) {
-		mm_memcap = BOOT_MEM_PM_BASE + n_frames*PAGE_SIZE;
+		mm_memcap = BOOT_MEM_KM_BASE + n_frames*PAGE_SIZE;
 		if ((n_frames % (PAGE_SIZE/sizeof(void*))) == 0) {
 			/* Need to expand PTE. */
 			pte_cap  = alloc_capid(CAP_PGTBL);

--- a/src/components/implementation/no_interface/vkernel/Makefile
+++ b/src/components/implementation/no_interface/vkernel/Makefile
@@ -1,0 +1,10 @@
+C_OBJS=micro_booter.o vkernel.o
+ASM_OBJS=cos_asm_scheduler.o testinv.o
+COMPONENT=vkernel_boot.o
+INTERFACES=
+DEPENDENCIES=
+IF_LIB=
+ADDITIONAL_LIBS=-lcobj_format -lcos_kernel_api
+
+include ../../Makefile.subsubdir
+MANDITORY_LIB=simple_stklib.o

--- a/src/components/implementation/no_interface/vkernel/micro_booter.c
+++ b/src/components/implementation/no_interface/vkernel/micro_booter.c
@@ -1,0 +1,579 @@
+#include <stdio.h>
+#include <string.h>
+
+#undef assert
+#ifndef assert
+/* On assert, immediately switch to the "exit" thread */
+#define assert(node) do { if (unlikely(!(node))) { debug_print("assert error in @ "); cos_thd_switch(VM_CAPTBL_SELF_EXITTHD_BASE);} } while(0)
+#endif
+
+#define PRINT_FN prints
+#define debug_print(str) (PRINT_FN(str __FILE__ ":" STR(__LINE__) ".\n"))
+#define BUG() do { debug_print("BUG @ "); *((int *)0) = 0; } while (0);
+#define BUG_DIVZERO() do { debug_print("Testing divide by zero fault @ "); int i = num / den; } while (0);
+#define EXIT() do { while (1) cos_thd_switch(VM_CAPTBL_SELF_EXITTHD_BASE); } while (0);
+
+#include <cos_component.h>
+#include <cobj_format.h>
+#include <cos_kernel_api.h>
+
+static void
+cos_llprint(char *s, int len)
+{ call_cap(PRINT_CAP_TEMP, (int)s, len, 0, 0); }
+
+int
+prints(char *s)
+{
+	int len = strlen(s);
+
+	cos_llprint(s, len);
+
+	return len;
+}
+
+int __attribute__((format(printf,1,2)))
+printc(char *fmt, ...)
+{
+	  char s[128];
+	  va_list arg_ptr;
+	  int ret, len = 128;
+
+	  va_start(arg_ptr, fmt);
+	  ret = vsnprintf(s, len, fmt, arg_ptr);
+	  va_end(arg_ptr);
+	  cos_llprint(s, ret);
+
+	  return ret;
+}
+
+int vmid = -1;
+#define PRINTVM(fmt, args...) printc("%d: " fmt, vmid , ##args)
+
+struct cos_compinfo booter_info;
+/* For Div-by-zero test */
+int num = 1, den = 0;
+
+#define ITER 10000
+#define TEST_NTHDS 5
+unsigned long tls_test[TEST_NTHDS];
+
+static unsigned long
+tls_get(size_t off)
+{
+	unsigned long val;
+
+	__asm__ __volatile__("movl %%gs:(%1), %0" : "=r" (val) : "r" (off) : );
+
+	return val;
+}
+
+static void
+tls_set(size_t off, unsigned long val)
+{ __asm__ __volatile__("movl %0, %%gs:(%1)" : : "r" (val), "r" (off) : "memory"); }
+
+static void
+thd_fn_perf(void *d)
+{
+	cos_thd_switch(BOOT_CAPTBL_SELF_INITTHD_BASE);
+
+	while(1) {
+		cos_thd_switch(BOOT_CAPTBL_SELF_INITTHD_BASE);
+	}
+	PRINTVM("Error, shouldn't get here!\n");
+}
+
+static void
+test_thds_perf(void)
+{
+	thdcap_t ts;
+	long long total_swt_cycles = 0;
+	long long start_swt_cycles = 0, end_swt_cycles = 0;
+	int i;
+
+	ts = cos_thd_alloc(&booter_info, booter_info.comp_cap, thd_fn_perf, NULL);
+	assert(ts);
+	cos_thd_switch(ts);
+
+	rdtscll(start_swt_cycles);
+	for (i = 0 ; i < ITER ; i++) {
+		cos_thd_switch(ts);
+	}
+	rdtscll(end_swt_cycles);
+	total_swt_cycles = (end_swt_cycles - start_swt_cycles) / 2LL;
+
+	PRINTVM("Average THD SWTCH (Total: %lld / Iterations: %lld ): %lld\n",
+		total_swt_cycles, (long long) ITER, (total_swt_cycles / (long long)ITER));
+}
+
+static void
+thd_fn(void *d)
+{
+	PRINTVM("\tNew thread %d with argument %d, capid %ld\n", cos_thdid(), (int)d, tls_test[(int)d]);
+	/* Test the TLS support! */
+	assert(tls_get(0) == tls_test[(int)d]);
+	while (1) cos_thd_switch(BOOT_CAPTBL_SELF_INITTHD_BASE);
+	PRINTVM("Error, shouldn't get here!\n");
+}
+
+static void
+test_thds(void)
+{
+	thdcap_t ts[TEST_NTHDS];
+	int i;
+	int ret;
+
+	for (i = 0 ; i < TEST_NTHDS ; i++) {
+		ts[i] = cos_thd_alloc(&booter_info, booter_info.comp_cap, thd_fn, (void *)i);
+		assert(ts[i]);
+		tls_test[i] = i;
+		cos_thd_mod(&booter_info, ts[i], &tls_test[i]);
+		PRINTVM("switchto %d @ %x\n", (int)ts[i], cos_introspect(&booter_info, ts[i], 0));
+		cos_thd_switch(ts[i]);
+	}
+
+        PRINTVM("test done\n");
+}
+
+#define TEST_NPAGES (1024*2) 	/* Testing with 8MB for now */
+
+static void
+test_mem(void)
+{
+	char *p, *s, *t, *prev;
+	int i;
+	const char *chk = "SUCCESS";
+
+	p = cos_page_bump_alloc(&booter_info);
+	assert(p);
+	strcpy(p, chk);
+
+	assert(0 == strcmp(chk, p));
+	PRINTVM("%s: Page allocation\n", p);
+
+	s = cos_page_bump_alloc(&booter_info);
+	assert(s);
+	prev = s;
+	for (i = 0 ; i < TEST_NPAGES ; i++) {
+		t = cos_page_bump_alloc(&booter_info);
+		assert(t && t == prev + 4096);
+		prev = t;
+	}
+	memset(s, 0, TEST_NPAGES * 4096);
+	PRINTVM("SUCCESS: Allocated and zeroed %d pages.\n", TEST_NPAGES);
+}
+
+volatile arcvcap_t rcc_global, rcp_global;
+volatile asndcap_t scp_global;
+int async_test_flag = 0;
+
+static void
+async_thd_fn_perf(void *thdcap)
+{
+	thdcap_t tc = (thdcap_t)thdcap;
+	arcvcap_t rc = rcc_global;
+	int i;
+
+	cos_rcv(rc);
+
+	for (i = 0 ; i < ITER + 1 ; i++) {
+		cos_rcv(rc);
+	}
+
+	cos_thd_switch(tc);
+}
+
+static void
+async_thd_parent_perf(void *thdcap)
+{
+	thdcap_t tc = (thdcap_t)thdcap;
+	arcvcap_t rc = rcp_global;
+	asndcap_t sc = scp_global;
+	long long total_asnd_cycles = 0;
+	long long start_asnd_cycles = 0, end_arcv_cycles = 0;
+	int i;
+
+	cos_asnd(sc);
+
+	rdtscll(start_asnd_cycles);
+	for (i = 0 ; i < ITER ; i++) {
+		cos_asnd(sc);
+	}
+	rdtscll(end_arcv_cycles);
+	total_asnd_cycles = (end_arcv_cycles - start_asnd_cycles) / 2;
+
+	PRINTVM("Average ASND/ARCV (Total: %lld / Iterations: %lld ): %lld\n",
+		total_asnd_cycles, (long long) (ITER), (total_asnd_cycles / (long long)(ITER)));
+
+	async_test_flag = 0;
+	cos_thd_switch(tc);
+}
+
+static void
+async_thd_fn(void *thdcap)
+{
+	thdcap_t tc = (thdcap_t)thdcap;
+	arcvcap_t rc = rcc_global;
+	thdid_t tid;
+	int rcving;
+	cycles_t cycles;
+	int pending;
+
+	PRINTVM("Asynchronous event thread handler.\t<-- rcving...\n");
+	pending = cos_rcv(rc);
+	PRINTVM("<-- pending %d\t<-- rcving...\n", pending);
+	pending = cos_rcv(rc);
+	PRINTVM("<-- pending %d\t<-- rcving...\n", pending);
+	pending = cos_rcv(rc);
+	PRINTVM("<-- Error: manually returning to snding thread.\n");
+	cos_thd_switch(tc);
+	PRINTVM("ERROR: in async thd *after* switching back to the snder.\n");
+	while (1) ;
+}
+
+static void
+async_thd_parent(void *thdcap)
+{
+	thdcap_t  tc = (thdcap_t)thdcap;
+	arcvcap_t rc = rcp_global;
+	asndcap_t sc = scp_global;
+	int ret, pending;
+	thdid_t tid;
+	int rcving;
+	cycles_t cycles;
+
+	PRINTVM("--> sending\n");
+	ret = cos_asnd(sc);
+	if (ret) PRINTVM("asnd returned %d.\n", ret);
+	PRINTVM("--> Back in the asnder.\t--> sending\n");
+	ret = cos_asnd(sc);
+	if (ret) PRINTVM("--> asnd returned %d.\n", ret);
+	PRINTVM("--> Back in the asnder.\t--> receiving to get notifications\n");
+	pending = cos_sched_rcv(rc, &tid, &rcving, &cycles);
+	PRINTVM("--> pending %d, thdid %d, rcving %d, cycles %lld\n", pending, tid, rcving, cycles);
+
+	async_test_flag = 0;
+	cos_thd_switch(tc);
+}
+
+static void
+test_async_endpoints(void)
+{
+	thdcap_t  tcp,  tcc;
+	tcap_t    tccp, tccc;
+	arcvcap_t rcp,  rcc;
+	int ret;
+
+	PRINTVM("Creating threads, and async end-points.\n");
+	/* parent rcv capabilities */
+	tcp = cos_thd_alloc(&booter_info, booter_info.comp_cap, async_thd_parent, (void*)BOOT_CAPTBL_SELF_INITTHD_BASE);
+	assert(tcp);
+	tccp = cos_tcap_alloc(&booter_info, TCAP_PRIO_MAX + 2);
+	assert(tccp);
+	rcp = cos_arcv_alloc(&booter_info, tcp, tccp, booter_info.comp_cap, BOOT_CAPTBL_SELF_INITRCV_BASE);
+	assert(rcp);
+	if ((ret = cos_tcap_transfer(rcp, BOOT_CAPTBL_SELF_INITTCAP_BASE, TCAP_RES_INF, TCAP_PRIO_MAX + 1))) {
+		PRINTVM("transfer failed: %d\n", ret);
+		assert(0);
+	}
+
+	/* child rcv capabilities */
+	tcc = cos_thd_alloc(&booter_info, booter_info.comp_cap, async_thd_fn, (void*)tcp);
+	assert(tcc);
+	tccc = cos_tcap_alloc(&booter_info, TCAP_PRIO_MAX + 1);
+	assert(tccc);
+	rcc = cos_arcv_alloc(&booter_info, tcc, tccc, booter_info.comp_cap, rcp);
+	assert(rcc);
+	if (cos_tcap_transfer(rcc, BOOT_CAPTBL_SELF_INITTCAP_BASE, TCAP_RES_INF, TCAP_PRIO_MAX)) assert(0);
+
+	/* make the snd channel to the child */
+	scp_global = cos_asnd_alloc(&booter_info, rcc, booter_info.captbl_cap);
+	assert(scp_global);
+
+	rcc_global = rcc;
+	rcp_global = rcp;
+
+	async_test_flag = 1;
+	while (async_test_flag) cos_thd_switch(tcp);
+
+	PRINTVM("Async end-point test successful.\tTest done.\n");
+}
+
+static void
+test_async_endpoints_perf(void)
+{
+	thdcap_t tcp, tcc;
+	tcap_t tccp, tccc;
+	arcvcap_t rcp, rcc;
+
+	/* parent rcv capabilities */
+	tcp = cos_thd_alloc(&booter_info, booter_info.comp_cap, async_thd_parent_perf, (void*)BOOT_CAPTBL_SELF_INITTHD_BASE);
+	assert(tcp);
+	tccp = cos_tcap_alloc(&booter_info, TCAP_PRIO_MAX + 2);
+	assert(tccp);
+	rcp = cos_arcv_alloc(&booter_info, tcp, tccp, booter_info.comp_cap, BOOT_CAPTBL_SELF_INITRCV_BASE);
+	assert(rcp);
+	if (cos_tcap_transfer(rcp, BOOT_CAPTBL_SELF_INITTCAP_BASE, TCAP_RES_INF, TCAP_PRIO_MAX + 1)) assert(0);
+
+	/* child rcv capabilities */
+	tcc = cos_thd_alloc(&booter_info, booter_info.comp_cap, async_thd_fn_perf, (void*)tcp);
+	assert(tcc);
+	tccc = cos_tcap_alloc(&booter_info, TCAP_PRIO_MAX + 1);
+	assert(tccc);
+	rcc = cos_arcv_alloc(&booter_info, tcc, tccc, booter_info.comp_cap, rcp);
+	assert(rcc);
+	if (cos_tcap_transfer(rcc, BOOT_CAPTBL_SELF_INITTCAP_BASE, TCAP_RES_INF, TCAP_PRIO_MAX)) assert(0);
+
+	/* make the snd channel to the child */
+	scp_global = cos_asnd_alloc(&booter_info, rcc, booter_info.captbl_cap);
+	assert(scp_global);
+
+	rcc_global = rcc;
+	rcp_global = rcp;
+
+	async_test_flag = 1;
+	while (async_test_flag) cos_thd_switch(tcp);
+}
+
+#define TCAP_NLAYERS 3
+static volatile int child_activated[TCAP_NLAYERS][2];
+/* tcap child/parent receive capabilities, and the send capability */
+static volatile arcvcap_t tc_crc[TCAP_NLAYERS][2], tc_prc[TCAP_NLAYERS][2];
+static volatile asndcap_t tc_sc[TCAP_NLAYERS][3];
+
+static void
+tcap_child(void *d)
+{
+	arcvcap_t __tc_crc = (arcvcap_t)d;
+
+	while (1) {
+		int pending;
+
+		pending = cos_rcv(__tc_crc);
+		PRINTVM("tcap_test:rcv: pending %d\n", pending);
+	}
+}
+
+static void
+tcap_parent(void *d)
+{
+	int i;
+	asndcap_t __tc_sc = (asndcap_t)d;
+
+	for (i = 0 ; i < ITER ; i++) {
+		cos_asnd(__tc_sc);
+	}
+}
+
+/* static void */
+/* test_tcaps(void) */
+/* { */
+/* 	thdcap_t tcp, tcc; */
+/* 	tcap_t tccp, tccc; */
+/* 	arcvcap_t rcp, rcc; */
+
+/* 	/\* parent rcv capabilities *\/ */
+/* 	tcp = cos_thd_alloc(&booter_info, booter_info.comp_cap, tcap_parent, (void*)BOOT_CAPTBL_SELF_INITTHD_BASE); */
+/* 	assert(tcp); */
+/* 	tccp = cos_tcap_split(&booter_info, BOOT_CAPTBL_SELF_INITTCAP_BASE, 0, 0); */
+/* 	assert(tccp); */
+/* 	rcp = cos_arcv_alloc(&booter_info, tcp, tccp, booter_info.comp_cap, BOOT_CAPTBL_SELF_INITRCV_BASE); */
+/* 	assert(rcp); */
+
+/* 	/\* child rcv capabilities *\/ */
+/* 	tcc = cos_thd_alloc(&booter_info, booter_info.comp_cap, tcap_child, (void*)tcp); */
+/* 	assert(tcc); */
+/* 	tccc = cos_tcap_split(&booter_info, BOOT_CAPTBL_SELF_INITTCAP_BASE, 0, 0); */
+/* 	assert(tccc); */
+/* 	rcc = cos_arcv_alloc(&booter_info, tcc, tccc, booter_info.comp_cap, rcp); */
+/* 	assert(rcc); */
+
+/* 	/\* make the snd channel to the child *\/ */
+/* 	scp_global = cos_asnd_alloc(&booter_info, rcc, booter_info.captbl_cap); */
+/* 	assert(scp_global); */
+
+/* 	rcc_global = rcc; */
+/* 	rcp_global = rcp; */
+
+/* 	async_test_flag = 1; */
+/* 	while (async_test_flag) cos_thd_switch(tcp); */
+/* } */
+
+static void
+spinner(void *d)
+{ while (1) ; }
+
+static void
+test_timer(void)
+{
+	int i;
+	thdcap_t tc;
+	cycles_t c = 0, p = 0, t = 0;
+
+	PRINTVM("Starting timer test.\n");
+	tc = cos_thd_alloc(&booter_info, booter_info.comp_cap, spinner, NULL);
+
+	for (i = 0 ; i <= 16 ; i++) {
+		thdid_t tid;
+		int rcving;
+		cycles_t cycles;
+
+		cos_sched_rcv(BOOT_CAPTBL_SELF_INITRCV_BASE, &tid, &rcving, &cycles);
+		cos_thd_switch(tc);
+		p = c;
+		rdtscll(c);
+		if (i > 0) t += c-p;
+	}
+
+	PRINTVM("\tCycles per tick (10 microseconds) = %lld\n", t/16);
+
+	PRINTVM("Timer test completed.\tSuccess.\n");
+}
+
+long long midinv_cycles = 0LL;
+
+int
+test_serverfn(int a, int b, int c)
+{
+	rdtscll(midinv_cycles);
+	return 0xDEADBEEF;
+}
+
+extern void *__inv_test_serverfn(int a, int b, int c);
+
+static inline
+int call_cap_mb(u32_t cap_no, int arg1, int arg2, int arg3)
+{
+	int ret;
+
+	/*
+	 * Which stack should we use for this invocation?  Simple, use
+	 * this stack, at the current sp.  This is essentially a
+	 * function call into another component, with odd calling
+	 * conventions.
+	 */
+	cap_no = (cap_no + 1) << COS_CAPABILITY_OFFSET;
+
+	__asm__ __volatile__( \
+		"pushl %%ebp\n\t" \
+		"movl %%esp, %%ebp\n\t" \
+		"movl %%esp, %%edx\n\t" \
+		"movl $1f, %%ecx\n\t" \
+		"sysenter\n\t" \
+		"1:\n\t" \
+		"popl %%ebp" \
+		: "=a" (ret)
+		: "a" (cap_no), "b" (arg1), "S" (arg2), "D" (arg3) \
+		: "memory", "cc", "ecx", "edx");
+
+	return ret;
+}
+
+static void
+test_inv(void)
+{
+	compcap_t cc;
+	sinvcap_t ic;
+	unsigned int r;
+
+	cc = cos_comp_alloc(&booter_info, booter_info.captbl_cap, booter_info.pgtbl_cap, (vaddr_t)NULL);
+	assert(cc > 0);
+	ic = cos_sinv_alloc(&booter_info, cc, (vaddr_t)__inv_test_serverfn);
+	assert(ic > 0);
+
+	r = call_cap_mb(ic, 1, 2, 3);
+	PRINTVM("Return from invocation: %x (== DEADBEEF?)\n", r);
+	PRINTVM("Test done.\n");
+}
+
+static void
+test_inv_perf(void)
+{
+	compcap_t cc;
+	sinvcap_t ic;
+	int i;
+	long long total_cycles = 0LL;
+	long long total_inv_cycles = 0LL, total_ret_cycles = 0LL;
+	unsigned int ret;
+
+	cc = cos_comp_alloc(&booter_info, booter_info.captbl_cap, booter_info.pgtbl_cap, (vaddr_t)NULL);
+	assert(cc > 0);
+	ic = cos_sinv_alloc(&booter_info, cc, (vaddr_t)__inv_test_serverfn);
+	assert(ic > 0);
+	ret = call_cap_mb(ic, 1, 2, 3);
+	assert(ret == 0xDEADBEEF);
+
+	for (i = 0 ; i < ITER ; i++) {
+		long long start_cycles = 0LL, end_cycles = 0LL;
+
+		midinv_cycles = 0LL;
+		rdtscll(start_cycles);
+		call_cap_mb(ic, 1, 2, 3);
+		rdtscll(end_cycles);
+		total_inv_cycles += (midinv_cycles - start_cycles);
+		total_ret_cycles += (end_cycles - midinv_cycles);
+	}
+
+	PRINTVM("Average SINV (Total: %lld / Iterations: %lld ): %lld\n",
+		total_inv_cycles, (long long) (ITER), (total_inv_cycles / (long long)(ITER)));
+	PRINTVM("Average SRET (Total: %lld / Iterations: %lld ): %lld\n",
+		total_ret_cycles, (long long) (ITER), (total_ret_cycles / (long long)(ITER)));
+}
+
+void
+test_captbl_expand(void)
+{
+	int i;
+	compcap_t cc;
+
+	cc = cos_comp_alloc(&booter_info, booter_info.captbl_cap, booter_info.pgtbl_cap, (vaddr_t)NULL);
+	assert(cc);
+	for (i = 0 ; i < 1024 ; i++) {
+		sinvcap_t ic;
+
+		ic = cos_sinv_alloc(&booter_info, cc, (vaddr_t)__inv_test_serverfn);
+		assert(ic > 0);
+	}
+	PRINTVM("Captbl expand SUCCESS.\n");
+}
+
+void
+test_run(void)
+{
+	test_thds();
+	test_thds_perf();
+
+	test_timer();
+
+	test_mem();
+
+	test_async_endpoints();
+	test_async_endpoints_perf();
+
+	test_inv();
+	test_inv_perf();
+
+	test_captbl_expand();
+}
+
+void
+term_fn(void *d)
+{
+	BUG_DIVZERO();
+}
+
+void
+vm_init(void *d)
+{
+	vmid = (int)d;
+	PRINTVM("Micro Booter started.\n");
+
+	cos_meminfo_init(&booter_info.mi, BOOT_MEM_KM_BASE, COS_VIRT_MACH_UNTYPED_SIZE);
+	cos_compinfo_init(&booter_info, BOOT_CAPTBL_SELF_PT, BOOT_CAPTBL_SELF_CT, BOOT_CAPTBL_SELF_COMP,
+			  (vaddr_t)cos_get_heap_ptr(), VM_CAPTBL_FREE, &booter_info);
+
+	test_run();
+	PRINTVM("Micro Booter done.\n");
+	EXIT();
+
+	return;
+}

--- a/src/components/implementation/no_interface/vkernel/testinv.S
+++ b/src/components/implementation/no_interface/vkernel/testinv.S
@@ -1,0 +1,18 @@
+/* Use the passed in stack in arg4 */
+
+#define RET_CAP (1 << 16)
+
+.text
+.globl __inv_test_serverfn
+.type  __inv_test_serverfn, @function
+__inv_test_serverfn:
+	movl %ebp, %esp
+	xor %ebp, %ebp
+        pushl %edi
+        pushl %esi
+        pushl %ebx
+        call test_serverfn
+        addl $12, %esp
+        movl %eax, %ecx
+        movl $RET_CAP, %eax
+        sysenter;

--- a/src/components/implementation/no_interface/vkernel/vkernel.c
+++ b/src/components/implementation/no_interface/vkernel/vkernel.c
@@ -2,6 +2,8 @@
 #include <cobj_format.h>
 #include <cos_kernel_api.h>
 
+#undef assert
+#define assert(node) do { if (unlikely(!(node))) { debug_print("assert error in @ "); *((int *)0) = 0; } } while (0)
 #define PRINT_FN prints
 #define debug_print(str) (PRINT_FN(str __FILE__ ":" STR(__LINE__) ".\n"))
 #define BUG() do { debug_print("BUG @ "); *((int *)0) = 0; } while (0);

--- a/src/components/implementation/no_interface/vkernel/vkernel.c
+++ b/src/components/implementation/no_interface/vkernel/vkernel.c
@@ -1,0 +1,186 @@
+#include <cos_component.h>
+#include <cobj_format.h>
+#include <cos_kernel_api.h>
+
+#define PRINT_FN prints
+#define debug_print(str) (PRINT_FN(str __FILE__ ":" STR(__LINE__) ".\n"))
+#define BUG() do { debug_print("BUG @ "); *((int *)0) = 0; } while (0);
+
+struct vms_info {
+	struct cos_compinfo cinfo;
+	captblcap_t ct;
+	pgtblcap_t pt;
+	compcap_t cc;
+	thdcap_t initthd, exitthd;
+	thdid_t inittid;
+	tcap_t inittcap;
+	arcvcap_t initrcv;
+} vmx_info[COS_VIRT_MACH_COUNT];
+
+struct vkernel_info {
+	struct cos_compinfo cinfo;
+
+	thdcap_t termthd;
+	asndcap_t vminitasnd[COS_VIRT_MACH_COUNT];
+} vk_info;
+
+extern vaddr_t cos_upcall_entry;
+extern void vm_init(void *);
+
+unsigned int ready_vms = COS_VIRT_MACH_COUNT;
+struct cos_compinfo *vk_cinfo = (struct cos_compinfo *)&vk_info.cinfo;
+
+void
+vk_terminate(void *d)
+{
+	BUG();
+}
+
+void
+vm_exit(void *d)
+{
+	ready_vms --;
+	vmx_info[(int)d].initthd = 0;	
+
+	printc("%d: EXIT\n", (int)d);
+	cos_thd_switch(BOOT_CAPTBL_SELF_INITTHD_BASE);
+}
+
+void
+scheduler(void) 
+{
+	static unsigned int i = 0;
+
+	while (ready_vms) {
+		thdid_t tid;
+		int rcving;
+		cycles_t cycles;
+		int pending = cos_sched_rcv(BOOT_CAPTBL_SELF_INITRCV_BASE, &tid, &rcving, &cycles);
+		int index   = i ++ % COS_VIRT_MACH_COUNT;
+		
+		if (vmx_info[index].initthd) {
+			cos_asnd(vk_info.vminitasnd[index]);
+		}
+	}
+	cos_thd_switch(BOOT_CAPTBL_SELF_INITTHD_BASE);
+}
+
+
+void
+cos_init(void)
+{
+	int id;
+
+	printc("vkernel: START\n");
+	assert(COS_VIRT_MACH_COUNT >= 2);
+
+	cos_meminfo_init(&vk_cinfo->mi, BOOT_MEM_KM_BASE, COS_MEM_KERN_PA_SZ);
+	cos_compinfo_init(vk_cinfo, BOOT_CAPTBL_SELF_PT, BOOT_CAPTBL_SELF_CT, BOOT_CAPTBL_SELF_COMP,
+			(vaddr_t)cos_get_heap_ptr(), BOOT_CAPTBL_FREE, vk_cinfo);
+
+	vk_info.termthd = cos_thd_alloc(vk_cinfo, vk_cinfo->comp_cap, vk_terminate, NULL);
+	assert(vk_info.termthd);
+
+	for (id = 0; id < COS_VIRT_MACH_COUNT; id ++) {
+		struct cos_compinfo *vm_cinfo = &vmx_info[id].cinfo;
+		struct vms_info *vm_info = &vmx_info[id];
+		int ret, vm_range, i;
+
+		printc("vkernel: VM%d Init START\n", id);
+		printc("\tForking VM\n");
+		vm_info->exitthd = cos_thd_alloc(vk_cinfo, vk_cinfo->comp_cap, vm_exit, (void *)id);
+		assert(vm_info->exitthd);
+		
+		vm_info->ct = cos_captbl_alloc(vk_cinfo);
+		assert(vm_info->ct);
+
+		vm_info->pt = cos_pgtbl_alloc(vk_cinfo);
+		assert(vm_info->pt);
+
+		vm_info->cc = cos_comp_alloc(vk_cinfo, vm_info->ct, vm_info->pt, (vaddr_t)&cos_upcall_entry);
+		assert(vm_info->cc);
+
+		cos_meminfo_init(&vm_cinfo->mi, BOOT_MEM_KM_BASE, COS_MEM_KERN_PA_SZ);
+		cos_compinfo_init(vm_cinfo, vm_info->pt, vm_info->ct, vm_info->cc,
+				(vaddr_t)BOOT_MEM_VM_BASE, VM_CAPTBL_FREE, vk_cinfo);
+
+		vm_info->initthd = cos_thd_alloc(vk_cinfo, vm_cinfo->comp_cap, vm_init, (void *)id);
+		assert(vm_info->initthd);
+		vm_info->inittid = (thdid_t)cos_introspect(vk_cinfo, vm_info->initthd, 9);
+		printc("\tInit thread= cap:%x tid:%x\n", (unsigned int)vm_info->initthd, (unsigned int)vm_info->inittid);
+
+		printc("\tCopying pgtbl, captbl, component capabilities\n");
+		ret = cos_cap_cpy_at(vm_cinfo, BOOT_CAPTBL_SELF_CT, vk_cinfo, vm_info->ct);
+		assert(ret == 0);
+		ret = cos_cap_cpy_at(vm_cinfo, BOOT_CAPTBL_SELF_PT, vk_cinfo, vm_info->pt);
+		assert(ret == 0);
+		ret = cos_cap_cpy_at(vm_cinfo, BOOT_CAPTBL_SELF_COMP, vk_cinfo, vm_info->cc);
+		assert(ret == 0);
+		
+
+		printc("\tCreating and copying required initial capabilities\n");
+		/*
+		 * TODO: Multi-core support to create INITIAL Capabilities per core
+		 */
+		ret = cos_cap_cpy_at(vm_cinfo, BOOT_CAPTBL_SELF_INITTHD_BASE, vk_cinfo, vm_info->initthd);
+		assert(ret == 0);
+		ret = cos_cap_cpy_at(vm_cinfo, BOOT_CAPTBL_SELF_INITHW_BASE, vk_cinfo, BOOT_CAPTBL_SELF_INITHW_BASE);
+		assert(ret == 0);
+		ret = cos_cap_cpy_at(vm_cinfo, VM_CAPTBL_SELF_EXITTHD_BASE, vk_cinfo, vm_info->exitthd);
+		assert(ret == 0);
+		
+		vm_info->inittcap = cos_tcap_alloc(vk_cinfo, TCAP_PRIO_MAX);
+		assert(vm_info->inittcap);
+
+		vm_info->initrcv = cos_arcv_alloc(vk_cinfo, vm_info->initthd, vm_info->inittcap, vk_cinfo->comp_cap, BOOT_CAPTBL_SELF_INITRCV_BASE);
+		assert(vm_info->initrcv);
+
+		ret = cos_tcap_transfer(vm_info->initrcv, BOOT_CAPTBL_SELF_INITTCAP_BASE, TCAP_RES_INF, TCAP_PRIO_MAX);
+		assert(ret == 0);
+
+		ret = cos_cap_cpy_at(vm_cinfo, BOOT_CAPTBL_SELF_INITTCAP_BASE, vk_cinfo, vm_info->inittcap);
+		assert(ret == 0);
+		ret = cos_cap_cpy_at(vm_cinfo, BOOT_CAPTBL_SELF_INITRCV_BASE, vk_cinfo, vm_info->initrcv);
+		assert(ret == 0);
+
+		/*
+		 * Create send end-point in VKernel to each VM's INITRCV end-point
+		 */
+		vk_info.vminitasnd[id] = cos_asnd_alloc(vk_cinfo, vm_info->initrcv, vk_cinfo->captbl_cap);
+		assert(vk_info.vminitasnd[id]);
+
+		/*
+		 * Create and copy booter comp virtual memory to each VM
+		 */
+		vm_range = (int)cos_get_heap_ptr() - BOOT_MEM_VM_BASE;
+		assert(vm_range > 0);
+		printc("\tMapping in Booter component's virtual memory (range:%u)\n", vm_range);
+		for (i = 0; i < vm_range; i += PAGE_SIZE) {
+			vaddr_t spg = (vaddr_t)cos_page_bump_alloc(vk_cinfo), dpg;
+			assert(spg);
+			
+			memcpy((void *)spg, (void *)(BOOT_MEM_VM_BASE + i), PAGE_SIZE);
+			
+			dpg = cos_mem_alias(vm_cinfo, vk_cinfo, spg);
+			assert(dpg);
+		}
+
+		printc("\tAllocating Untyped memory\n");
+		cos_meminfo_alloc(vm_cinfo, BOOT_MEM_KM_BASE, COS_VIRT_MACH_UNTYPED_SIZE);
+
+		printc("vkernel: VM%d Init END\n", id);
+	}
+
+	printc("------------------[ VKernel & VMs init complete ]------------------\n");
+	printc("Starting Scheduler\n");
+	cos_hw_attach(BOOT_CAPTBL_SELF_INITHW_BASE, HW_PERIODIC, BOOT_CAPTBL_SELF_INITRCV_BASE);
+	printc("\t%d cycles per microsecond\n", cos_hw_cycles_per_usec(BOOT_CAPTBL_SELF_INITHW_BASE));
+	scheduler();
+	cos_hw_detach(BOOT_CAPTBL_SELF_INITHW_BASE, HW_PERIODIC);
+	printc("vkernel: END\n");
+	cos_thd_switch(vk_info.termthd);
+
+	printc("DEAD END\n");
+
+	return;
+}

--- a/src/components/implementation/tests/micro_booter/micro_booter.c
+++ b/src/components/implementation/tests/micro_booter/micro_booter.c
@@ -540,11 +540,15 @@ test_run(void)
 	cos_hw_attach(BOOT_CAPTBL_SELF_INITHW_BASE, HW_PERIODIC, BOOT_CAPTBL_SELF_INITRCV_BASE);
 	printc("\t%d cycles per microsecond\n", cos_hw_cycles_per_usec(BOOT_CAPTBL_SELF_INITHW_BASE));
 
-	test_thds();
-	test_thds_perf();
-
 	test_timer();
 	cos_hw_detach(BOOT_CAPTBL_SELF_INITHW_BASE, HW_PERIODIC);
+
+	/* 
+	 * It is ideal to ubenchmark kernel API with timer interrupt detached,
+	 * Not so much for unit-tests
+	 */
+	test_thds();
+	test_thds_perf();
 
 	test_mem();
 

--- a/src/components/implementation/tests/micro_llping/ping.c
+++ b/src/components/implementation/tests/micro_llping/ping.c
@@ -875,7 +875,7 @@ void retype_test(void)
 	last_tick = printc("FLUSH!!");
 	for (i = 0; i < ITER; i++) {
 		s = tsc_start();
-#define RETYPE_ADDR (BOOT_MEM_PM_BASE + COS_MAX_MEMORY*PAGE_SIZE - RETYPE_MEM_SIZE)
+#define RETYPE_ADDR (BOOT_MEM_KM_BASE + COS_MAX_MEMORY*PAGE_SIZE - RETYPE_MEM_SIZE)
 		ret = call_cap_op(PING_ROOTPGTBL, CAPTBL_OP_MEM_RETYPE2USER,
 				  RETYPE_ADDR, 0, 0, 0);
 		rdtscll(e);

--- a/src/components/include/cos_kernel_api.h
+++ b/src/components/include/cos_kernel_api.h
@@ -49,12 +49,13 @@ void cos_compinfo_init(struct cos_compinfo *ci, captblcap_t pgtbl_cap, pgtblcap_
  * to this component's captbls.
  */
 void cos_meminfo_init(struct cos_meminfo *mi, vaddr_t untyped_ptr, unsigned long untyped_sz);
+void cos_meminfo_alloc(struct cos_compinfo *ci, vaddr_t untyped_ptr, unsigned long untyped_sz);
 
 /*
  * This uses the next three functions to allocate a new component and
  * correctly populate ci (allocating all resources from ci_resources).
  */
-int         cos_compinfo_alloc(struct cos_compinfo *ci, vaddr_t heap_ptr, vaddr_t entry, struct cos_compinfo *ci_resources);
+int         cos_compinfo_alloc(struct cos_compinfo *ci, vaddr_t heap_ptr, capid_t cap_frontier, vaddr_t entry, struct cos_compinfo *ci_resources);
 captblcap_t cos_captbl_alloc(struct cos_compinfo *ci);
 pgtblcap_t  cos_pgtbl_alloc(struct cos_compinfo *ci);
 compcap_t   cos_comp_alloc(struct cos_compinfo *ci, captblcap_t ctc, pgtblcap_t ptc, vaddr_t entry);
@@ -69,6 +70,9 @@ asndcap_t cos_asnd_alloc(struct cos_compinfo *ci, arcvcap_t arcvcap, captblcap_t
 
 void *cos_page_bump_alloc(struct cos_compinfo *ci);
 
+capid_t cos_cap_cpy(struct cos_compinfo *dstci, struct cos_compinfo *srcci, cap_t srcctype, capid_t srccap);
+int cos_cap_cpy_at(struct cos_compinfo *dstci, capid_t dstcap, struct cos_compinfo *srcci, capid_t srccap);
+
 int cos_thd_switch(thdcap_t c);
 #define CAP_NULL 0
 int cos_switch(thdcap_t c, tcap_t t, tcap_prio_t p, tcap_res_t r, arcvcap_t rcv);
@@ -82,8 +86,10 @@ int cos_sched_rcv(arcvcap_t rcv, thdid_t *thdid, int *rcving, cycles_t *cycles);
 
 int cos_introspect(struct cos_compinfo *ci, capid_t cap, unsigned long op);
 
-int cos_mem_alias(pgtblcap_t ptdst, vaddr_t dst, pgtblcap_t ptsrc, vaddr_t src);
-int cos_mem_move(pgtblcap_t ptdst, vaddr_t dst, pgtblcap_t ptsrc, vaddr_t src);
+vaddr_t cos_mem_alias(struct cos_compinfo *dstci, struct cos_compinfo *srcci, vaddr_t src);
+int cos_mem_alias_at(struct cos_compinfo *dstci, vaddr_t dst, struct cos_compinfo *srcci, vaddr_t src);
+vaddr_t cos_mem_move(struct cos_compinfo *dstci, struct cos_compinfo *srcci, vaddr_t src);
+int cos_mem_move_at(struct cos_compinfo *dstci, vaddr_t dst, struct cos_compinfo *srcci, vaddr_t src);
 int cos_mem_remove(pgtblcap_t pt, vaddr_t addr);
 
 /* Tcap operations */
@@ -96,7 +102,7 @@ int cos_tcap_merge(tcap_t dst, tcap_t rm);
 hwcap_t cos_hw_alloc(struct cos_compinfo *ci, u32_t bitmap);
 int cos_hw_attach(hwcap_t hwc, hwid_t hwid, arcvcap_t rcvcap);
 int cos_hw_detach(hwcap_t hwc, hwid_t hwid);
-void *cos_hw_map(struct cos_compinfo *ci, hwcap_t hwc, paddr_t pa);
+void *cos_hw_map(struct cos_compinfo *ci, hwcap_t hwc, paddr_t pa, unsigned int len);
 int cos_hw_cycles_per_usec(hwcap_t hwc);
 
 

--- a/src/kernel/capinv.c
+++ b/src/kernel/capinv.c
@@ -1140,6 +1140,8 @@ composite_syscall_slowpath(struct pt_regs *regs, int *thd_switch)
 
 			ret = cap_introspect(ctin, capin, op, &retval);
 			if (!ret) ret = retval;
+			
+			break;
 		}
 		case CAPTBL_OP_HW_ACTIVATE:
 		{

--- a/src/kernel/include/shared/consts.h
+++ b/src/kernel/include/shared/consts.h
@@ -107,8 +107,8 @@ struct pt_regs {
 #define COS_NUM_ATOMIC_SECTIONS 10
 
 /* # of pages */
-#define COS_MAX_MEMORY    (COS_MEM_USER_PA_SZ/PAGE_SIZE)  /* # of pages */
-#define COS_MEM_BOUND     (COS_MEM_USER_PA + COS_MAX_MEMORY*PAGE_SIZE) /* highest physical address */
+#define COS_MAX_MEMORY    (COS_MEM_KERN_PA_SZ/PAGE_SIZE)  /* # of pages */
+#define COS_MEM_BOUND     (COS_MEM_KERN_PA + COS_MAX_MEMORY*PAGE_SIZE) /* highest physical address */
 
 /* These are deprecated, use the macros they reference */
 #define KERN_MEM_ORDER    (COS_MEM_KERN_PA_ORDER-PAGE_ORDER)

--- a/src/kernel/include/shared/cos_config.h
+++ b/src/kernel/include/shared/cos_config.h
@@ -17,9 +17,6 @@
 
 #include "cpu_ghz.h"
 
-/* we already use 16 MB of kernel memory + the kernel img, thus 32MB offset for this: */
-#define COS_MEM_USER_PA       (1<<25)
-#define COS_MEM_USER_PA_SZ    (1<<25) /* start with 32MB of memory */
 
 /*
  * 1 MB, note that this is not the PA of kernel-usable memory, instead
@@ -27,13 +24,12 @@
  * linker script (.ld) as well.
  */
 #define COS_MEM_KERN_PA (0x00100000)
-#define COS_MEM_KERN_PA_ORDER (25)
+#define COS_MEM_KERN_PA_ORDER (29)
 #define COS_MEM_KERN_PA_SZ    (1<<COS_MEM_KERN_PA_ORDER)
 
 #define COS_MEM_COMP_START_VA ((1<<30) + (1<<22)) /* 1GB + 4MB (a relic) */
 #define COS_MEM_KERN_START_VA (0xc0000000) //COS_MEM_KERN_PA     /* currently, we don't do kernel relocation */
 
-#define COS_MEM_USER_VA_SZ (1<<31) /* 2 GB */
 #define COS_MEM_KERN_VA_SZ (1<<24) /* 16 MB from KERN_START_VA + end of kernel image onward */
 
 /* To get more memory, we need many PTE caps in the captbl. So give
@@ -65,7 +61,7 @@
 #define NUM_CPU_COS            (NUM_CPU > 1 ? NUM_CPU - 1 : 1)
 
 /* Composite user memory uses physical memory above this. */
-#define COS_MEM_START          COS_MEM_USER_PA
+#define COS_MEM_START          COS_MEM_KERN_PA
 
 /* NUM_CPU_SOCKETS defined in cpu_ghz.h. The information is used for
  * intelligent IPI distribution. */

--- a/src/kernel/include/shared/cos_types.h
+++ b/src/kernel/include/shared/cos_types.h
@@ -268,8 +268,7 @@ enum {
 
 enum {
 	BOOT_MEM_VM_BASE = (COS_MEM_COMP_START_VA + (1<<22)), /* @ 1G + 8M */
-	BOOT_MEM_KM_BASE = PAGE_SIZE, /* kernel memory @ first page, not at address 0 to avoid NULL */
-	BOOT_MEM_PM_BASE = 0x80000000, /* user memory @ 2 GB */
+	BOOT_MEM_KM_BASE = PAGE_SIZE, /* kernel & user memory @ first page, not at address 0 to avoid NULL */
 };
 
 enum {

--- a/src/kernel/include/shared/cos_types.h
+++ b/src/kernel/include/shared/cos_types.h
@@ -187,6 +187,9 @@ typedef enum {
 
 #define CAPTBL_EXPAND_SZ 128
 
+#define COS_VIRT_MACH_COUNT        2
+#define COS_VIRT_MACH_UNTYPED_SIZE (1<<26) //64MB
+
 /* a function instead of a struct to enable inlining + constant prop */
 static inline cap_sz_t
 __captbl_cap2sz(cap_t c)
@@ -250,9 +253,15 @@ enum {
 	BOOT_CAPTBL_SELF_INITTCAP_BASE = BOOT_CAPTBL_SELF_INITTHD_BASE + NUM_CPU_COS*CAP16B_IDSZ,
 	BOOT_CAPTBL_SELF_INITRCV_BASE  = round_up_to_pow2(BOOT_CAPTBL_SELF_INITTCAP_BASE + NUM_CPU_COS*CAP16B_IDSZ, CAPMAX_ENTRY_SZ),
 	BOOT_CAPTBL_SELF_INITHW_BASE   = round_up_to_pow2(BOOT_CAPTBL_SELF_INITRCV_BASE + NUM_CPU_COS*CAP64B_IDSZ, CAPMAX_ENTRY_SZ),
-	BOOT_CAPTBL_LAST_CAP           = BOOT_CAPTBL_SELF_INITHW_BASE + CAP32B_IDSZ,
+	BOOT_CAPTBL_LAST_CAP           = round_up_to_pow2(BOOT_CAPTBL_SELF_INITHW_BASE + CAP32B_IDSZ, CAPMAX_ENTRY_SZ),
 	/* round up to next entry */
 	BOOT_CAPTBL_FREE               = round_up_to_pow2(BOOT_CAPTBL_LAST_CAP, CAPMAX_ENTRY_SZ)
+};
+
+enum {
+	VM_CAPTBL_SELF_EXITTHD_BASE    = BOOT_CAPTBL_FREE,
+	VM_CAPTBL_LAST_CAP             = round_up_to_pow2(VM_CAPTBL_SELF_EXITTHD_BASE + NUM_CPU_COS*CAP16B_IDSZ, CAPMAX_ENTRY_SZ),
+	VM_CAPTBL_FREE                 = round_up_to_pow2(VM_CAPTBL_LAST_CAP, CAPMAX_ENTRY_SZ),
 };
 
 enum {
@@ -838,8 +847,8 @@ static inline void
 cos_mem_fence(void)
 { __asm__ __volatile__("mfence" ::: "memory"); }
 
-// ncpu * 16 (or max 256) entries. can be increased if necessary.
-#define COS_THD_INIT_REGION_SIZE (((NUM_CPU*16) > (1<<8)) ? (1<<8) : (NUM_CPU*16))
+/* 256 entries. can be increased if necessary */
+#define COS_THD_INIT_REGION_SIZE (1<<8)
 // Static entries are after the dynamic allocated entries
 #define COS_STATIC_THD_ENTRY(i) ((i + COS_THD_INIT_REGION_SIZE + 1))
 

--- a/src/kernel/include/thd.h
+++ b/src/kernel/include/thd.h
@@ -424,6 +424,7 @@ thd_introspect(struct thread *t, unsigned long op, unsigned long *retval)
 	case 6: *retval = t->regs.dx; break;
 	case 7: *retval = t->regs.si; break;
 	case 8: *retval = t->regs.di; break;
+	case 9: *retval = t->tid; break;
 	default: return -EINVAL;
 	}
 	return 0;

--- a/src/kernel/retype_tbl.c
+++ b/src/kernel/retype_tbl.c
@@ -125,7 +125,6 @@ retypetbl_retype2user(void *pa)
 int
 retypetbl_retype2kern(void *pa)
 {
-	if ((unsigned long)pa >= COS_MEM_USER_PA) return -EINVAL;
 	return mod_mem_type(pa, RETYPETBL_KERN);
 }
 

--- a/src/platform/i386/qemu.sh
+++ b/src/platform/i386/qemu.sh
@@ -11,5 +11,5 @@ fi
 
 MODULES=$(sh $1 | awk '/^Writing image/ { print $3; }' | tr '\n' ' ')
 
-qemu-system-i386 -m 128 -nographic -kernel kernel.img -no-reboot -s -initrd "$(echo $MODULES | tr ' ' ',')"
+qemu-system-i386 -m 768 -nographic -kernel kernel.img -no-reboot -s -initrd "$(echo $MODULES | tr ' ' ',')"
 

--- a/src/platform/i386/runscripts/vkernel_boot.sh
+++ b/src/platform/i386/runscripts/vkernel_boot.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+cp vkernel_boot.o llboot.o
+./cos_linker "llboot.o, ;llpong.o, :" ./gen_client_stub


### PR DESCRIPTION
### Summary of this PR

Major feature added is vkernel, which boots up multiple VMs (components) and runs micro_booter (unit & ubench tests) in each of the components. vkernel component schedules VMs in a simple round-robin way. Added API to allocate untyped memory to each VM starting from the end of the untyped_frontier for isolated chunck of memory for each VM. 
Fixed a bug that doesn't copy kernel PTEs into the booter component's pgtbl. 

Todo in vkernel: (Which I'll add iteratively, along with if any review comments in this pull-request)
1. Shared-memory feature
2. cross-vm communication channels
3. asnd/rcv capabilities between vkernel<->vms for tcaps delegation.

### Code Quality

As part of this pull request, I've considered the following:

Style:

- [x] Comments adhere to the Style Guide (SG)
- [x] Spacing adhere's to the SG 
- [x] Naming adhere's to the SG
- [x] All other aspects of the SG are adhered to, or exceptions are justified in this pull request

Code Craftsmanship:

- [x] I've made an attempt to remove all redundant code
- [x] I've considered ways in which my changes might impact existing code, and cleaned it up
- [x] I've formatted the code in an effort to make it easier to read (proper error handling, function use, etc...)
- [x] I've commented appropriately where code is tricky
- [x] I agree that there is no "throw-away" code, and that code in this PR is of high quality: *any such hackish code is well commented with `TODO`/`FIXME`s*
