### PR TITLE
Timer calibration, Tcaps budgets update and ubench for budgets

### DIFF
--- a/src/components/implementation/no_interface/vkernel/micro_booter.c
+++ b/src/components/implementation/no_interface/vkernel/micro_booter.c
@@ -40,15 +40,6 @@ int num = 1, den = 0;
 /* virtual machine id */
 int vmid;
 
-/* vkernel handles timer interrupts */
-void
-timer_attach(void)
-{ }
-
-void
-timer_detach(void)
-{ }
-
 void
 vm_init(void *d)
 {

--- a/src/components/implementation/no_interface/vkernel/micro_booter.h
+++ b/src/components/implementation/no_interface/vkernel/micro_booter.h
@@ -47,7 +47,5 @@ tls_set(size_t off, unsigned long val)
 extern int prints(char *s);
 extern int printc(char *fmt, ...);
 extern void test_run(void);
-extern void timer_attach(void);
-extern void timer_detach(void);
 
 #endif /* MICRO_BOOTER_H */

--- a/src/components/implementation/no_interface/vkernel/vkernel.c
+++ b/src/components/implementation/no_interface/vkernel/vkernel.c
@@ -73,7 +73,7 @@ scheduler(void)
 void
 cos_init(void)
 {
-	int id;
+	int id, cycs;
 
 	printc("vkernel: START\n");
 	assert(VM_COUNT >= 2);
@@ -84,6 +84,9 @@ cos_init(void)
 
 	vk_info.termthd = cos_thd_alloc(vk_cinfo, vk_cinfo->comp_cap, vk_terminate, NULL);
 	assert(vk_info.termthd);
+
+	while (!(cycs = cos_hw_cycles_per_usec(BOOT_CAPTBL_SELF_INITHW_BASE))) ;
+	printc("\t%d cycles per microsecond\n", cycs);
 
 	for (id = 0 ; id < VM_COUNT ; id ++) {
 		struct cos_compinfo *vm_cinfo = &vmx_info[id].cinfo;
@@ -184,13 +187,9 @@ cos_init(void)
 	}
 
 	printc("Starting Scheduler\n");
-	cos_hw_attach(BOOT_CAPTBL_SELF_INITHW_BASE, HW_PERIODIC, BOOT_CAPTBL_SELF_INITRCV_BASE);
-	printc("\t%d cycles per microsecond\n", cos_hw_cycles_per_usec(BOOT_CAPTBL_SELF_INITHW_BASE));
 	printc("------------------[ VKernel & VMs init complete ]------------------\n");
 
 	scheduler();
-
-	cos_hw_detach(BOOT_CAPTBL_SELF_INITHW_BASE, HW_PERIODIC);
 
 	printc("vkernel: END\n");
 	cos_thd_switch(vk_info.termthd);

--- a/src/components/implementation/no_interface/vkernel/vkernel.c
+++ b/src/components/implementation/no_interface/vkernel/vkernel.c
@@ -46,7 +46,7 @@ vm_exit(void *d)
 	ready_vms --;
 	vmx_info[(int)d].initthd = 0;	
 
-	cos_thd_switch(BOOT_CAPTBL_SELF_INITTHD_BASE);
+	while (1) cos_thd_switch(BOOT_CAPTBL_SELF_INITTHD_BASE);
 }
 
 void

--- a/src/components/implementation/tests/micro_booter/mb_tests.c
+++ b/src/components/implementation/tests/micro_booter/mb_tests.c
@@ -355,14 +355,15 @@ test_timer(void)
 		cycles_t cycles, now;
 		tcap_time_t timer;
 
-		/* FIXME: we should avoid calling this two times in the common case, return "more evts" */
-		while (cos_sched_rcv(BOOT_CAPTBL_SELF_INITRCV_BASE, &tid, &rcving, &cycles) != 0) ;
 		rdtscll(now);
 		timer = tcap_cyc2time(now + 1000 * cyc_per_usec);
 		cos_switch(tc, BOOT_CAPTBL_SELF_INITTCAP_BASE, 0, timer, BOOT_CAPTBL_SELF_INITRCV_BASE);
 		p = c;
 		rdtscll(c);
 		if (i > 0) t += c-p;
+
+		/* FIXME: we should avoid calling this two times in the common case, return "more evts" */
+		while (cos_sched_rcv(BOOT_CAPTBL_SELF_INITRCV_BASE, &tid, &rcving, &cycles) != 0) ;
 	}
 
 	PRINTC("\tCycles per tick (1000 microseconds) = %lld\n", t/16);
@@ -413,14 +414,21 @@ test_budgets(void)
 
 	PRINTC("Budget switch latencies: ");
 	for (i = 1 ; i < 10 ; i++) {
+		thdid_t  tid;
+		int      rcving;
+		cycles_t cycles;
+
 		if (cos_tcap_transfer(bt.c.rc, BOOT_CAPTBL_SELF_INITTCAP_BASE, i * 100000, TCAP_PRIO_MAX + 2)) assert(0);
 
 		rdtscll(s);
 		if (cos_switch(bt.c.tc, bt.c.tcc, TCAP_PRIO_MAX + 2, TCAP_RES_INF, BOOT_CAPTBL_SELF_INITRCV_BASE)) assert(0);
 		rdtscll(e);
 		PRINTC("%lld,\t", e-s);
+
+		/* FIXME: we should avoid calling this two times in the common case, return "more evts" */
+		while (cos_sched_rcv(BOOT_CAPTBL_SELF_INITRCV_BASE, &tid, &rcving, &cycles) != 0) ;
 	}
-	PRINTC("\n");
+	PRINTC("Done.\n");
 }
 
 long long midinv_cycles = 0LL;

--- a/src/components/implementation/tests/micro_booter/mb_tests.c
+++ b/src/components/implementation/tests/micro_booter/mb_tests.c
@@ -533,15 +533,9 @@ test_captbl_expand(void)
 void
 test_run(void)
 {
-	timer_attach();
-	timer_detach();
 	test_timer();
 	test_budgets();
 
-	/*
-	 * It is ideal to ubenchmark kernel API with timer interrupt detached,
-	 * Not so much for unit-tests
-	 */
 	test_thds();
 	test_thds_perf();
 

--- a/src/components/implementation/tests/micro_booter/micro_booter.c
+++ b/src/components/implementation/tests/micro_booter/micro_booter.c
@@ -41,25 +41,19 @@ term_fn(void *d)
 { BUG_DIVZERO(); }
 
 void
-timer_attach(void)
-{
-	cos_hw_attach(BOOT_CAPTBL_SELF_INITHW_BASE, HW_PERIODIC, BOOT_CAPTBL_SELF_INITRCV_BASE);
-	printc("\t%d cycles per microsecond\n", cos_hw_cycles_per_usec(BOOT_CAPTBL_SELF_INITHW_BASE));
-}
-
-void
-timer_detach(void)
-{ cos_hw_detach(BOOT_CAPTBL_SELF_INITHW_BASE, HW_PERIODIC); }
-
-void
 cos_init(void)
 {
+	int cycs;
+
 	cos_meminfo_init(&booter_info.mi, BOOT_MEM_KM_BASE, COS_MEM_KERN_PA_SZ, BOOT_CAPTBL_SELF_UNTYPED_PT);
 	cos_compinfo_init(&booter_info, BOOT_CAPTBL_SELF_PT, BOOT_CAPTBL_SELF_CT, BOOT_CAPTBL_SELF_COMP,
 			  (vaddr_t)cos_get_heap_ptr(), BOOT_CAPTBL_FREE, &booter_info);
 
 	termthd = cos_thd_alloc(&booter_info, booter_info.comp_cap, term_fn, NULL);
 	assert(termthd);
+
+	while (!(cycs = cos_hw_cycles_per_usec(BOOT_CAPTBL_SELF_INITHW_BASE))) ;
+	printc("\t%d cycles per microsecond\n", cycs);
 
 	PRINTC("\nMicro Booter started.\n");
 	test_run();

--- a/src/components/implementation/tests/micro_booter/micro_booter.h
+++ b/src/components/implementation/tests/micro_booter/micro_booter.h
@@ -44,7 +44,5 @@ tls_set(size_t off, unsigned long val)
 extern int prints(char *s);
 extern int printc(char *fmt, ...);
 extern void test_run(void);
-extern void timer_attach(void);
-extern void timer_detach(void);
 
 #endif /* MICRO_BOOTER_H */

--- a/src/kernel/capinv.c
+++ b/src/kernel/capinv.c
@@ -512,7 +512,9 @@ cap_thd_op(struct cap_thd *thd_cap, struct thread *thd, struct pt_regs *regs,
 	struct thread *next = thd_cap->t;
 	capid_t arcv        = (__userregs_get1(regs) << 16) >> 16;
 	capid_t tc          = __userregs_get1(regs) >> 16;
-	tcap_prio_t prio    = (tcap_prio_t)__userregs_get3(regs) | (tcap_prio_t)__userregs_get2(regs);
+	u32_t prio_higher   = __userregs_get3(regs);
+	u32_t prio_lower    = __userregs_get2(regs);
+	tcap_prio_t prio    = (tcap_prio_t)prio_higher << 32 | (tcap_prio_t)prio_lower;
 	tcap_time_t timeout = (tcap_time_t)__userregs_get4(regs);
 	struct tcap *tcap   = tcap_current(cos_info);
 
@@ -731,7 +733,8 @@ cap_arcv_op(struct cap_arcv *arcv, struct thread *thd, struct pt_regs *regs,
 
 		__userregs_set(regs, 0, __userregs_getsp(regs), __userregs_getip(regs));
 		thd_state_evt_deliver(thd, &a, &b);
-		__userregs_setretvals(regs, thd_rcvcap_pending_dec(thd), a, b);
+		thd_rcvcap_pending_dec(thd);
+		__userregs_setretvals(regs, thd_rcvcap_pending(thd), a, b);
 
 		return 0;
 	}

--- a/src/kernel/include/list.h
+++ b/src/kernel/include/list.h
@@ -26,6 +26,15 @@ list_init(struct list_node *l, void *obj)
 }
 
 static inline void
+list_add_before(struct list_node *l, struct list_node *new)
+{
+	new->next = l;
+	new->prev = l->prev;
+	l->prev->next = new;
+	l->prev = new;
+}
+
+static inline void
 list_add_after(struct list_node *l, struct list_node *new)
 {
 	new->next     = l->next;

--- a/src/kernel/tcap.c
+++ b/src/kernel/tcap.c
@@ -76,7 +76,7 @@ __tcap_budget_xfer(struct tcap *d, struct tcap *s, tcap_res_t cycles)
 	if (!TCAP_RES_IS_INF(bd->cycles)) bd->cycles += cycles;
 	if (!TCAP_RES_IS_INF(bs->cycles)) bs->cycles -= cycles;
 done:
-	if (!tcap_is_active(d)) tcap_active_add_after(s, d);
+	if (!tcap_is_active(d)) tcap_active_add_before(s, d);
 	if (tcap_expended(s))   tcap_active_rem(s);
 
 	return 0;

--- a/src/platform/i386/kernel.h
+++ b/src/platform/i386/kernel.h
@@ -32,7 +32,7 @@ typedef enum {
 	TIMER_ONESHOT  = 1,
 } timer_type_t;
 
-#define TIMER_DEFAULT_US_INTERARRIVAL 100 /* US = microseconds */
+#define TIMER_DEFAULT_US_INTERARRIVAL 1000 /* US = microseconds */
 
 void timer_set(timer_type_t timer_type, u64_t cycles);
 void timer_init(void);

--- a/src/platform/i386/timer.c
+++ b/src/platform/i386/timer.c
@@ -88,8 +88,8 @@ volatile struct hpet_timer {
 
 #define PICO_PER_MICRO           1000000UL
 #define FEMPTO_PER_PICO          1000UL
-#define TIMER_CALIBRATION_ITER   16
-#define TIMER_ERROR_BOUND_FACTOR 128
+#define TIMER_CALIBRATION_ITER   256
+#define TIMER_ERROR_BOUND_FACTOR 256
 static int timer_calibration_init = 1;
 static unsigned long timer_cycles_per_hpetcyc = TIMER_ERROR_BOUND_FACTOR;
 static unsigned long cycles_per_tick;
@@ -113,6 +113,20 @@ timer_cpu2hpet_cycles(u64_t cycles)
 }
 
 static void
+timer_disable(timer_type_t timer_type)
+{
+	/* Disable timer interrupts */
+	*hpet_config ^= ~1;
+
+	/* Disable timer interrupt of timer_type */
+	hpet_timers[timer_type].config = 0;
+	hpet_timers[timer_type].compare = 0;
+
+	/* Enable timer interrupts */
+	*hpet_config |= 1;
+}
+
+static void
 timer_calibration(void)
 {
 	static int   cnt = 0;
@@ -131,6 +145,9 @@ timer_calibration(void)
 		timer_cycles_per_hpetcyc = (TIMER_ERROR_BOUND_FACTOR * cycles_per_tick) / hpetcyc_per_tick;
 		printk("Timer calibrated:\n\tCPU cycles per HPET tick: %ld\n\tHPET ticks in %d us: %ld\n",
 		       timer_cycles_per_hpetcyc/TIMER_ERROR_BOUND_FACTOR, TIMER_DEFAULT_US_INTERARRIVAL, hpetcyc_per_tick);
+
+		timer_disable(TIMER_PERIODIC);
+		timer_disable(TIMER_PERIODIC);
 	}
 	cnt++;
 }
@@ -171,7 +188,6 @@ void
 timer_set(timer_type_t timer_type, u64_t cycles)
 {
 	u64_t outconfig = TN_INT_TYPE_CNF | TN_INT_ENB_CNF;
-	int timer = 0;
 
 	cycles = timer_cpu2hpet_cycles(cycles);
 
@@ -181,16 +197,15 @@ timer_set(timer_type_t timer_type, u64_t cycles)
 	/* Reset main counter */
 	if (timer_type == TIMER_ONESHOT) {
 		/* Set a static value to count up to */
-		timer = 1;
-		hpet_timers[timer].config = outconfig;
+		hpet_timers[timer_type].config = outconfig;
 		cycles += HPET_COUNTER;
 	} else {
 		/* Set a periodic value */
-		hpet_timers[timer].config = outconfig | TN_TYPE_CNF | TN_VAL_SET_CNF;
+		hpet_timers[timer_type].config = outconfig | TN_TYPE_CNF | TN_VAL_SET_CNF;
 		/* Reset main counter */
 		HPET_COUNTER = 0x00;
 	}
-	hpet_timers[timer].compare = cycles;
+	hpet_timers[timer_type].compare = cycles;
 
 	/* Enable timer interrupts */
 	*hpet_config |= 1;


### PR DESCRIPTION
### Summary of this PR

Changed timer calibration configuration, disabling PERIODIC after calibration. 
Updated Tcaps budgets to fix some bugs and border cases.
Updated ubench tests for Tcaps budgets. 

### Code Quality

As part of this pull request, I've considered the following:

Style:

- [x] Comments adhere to the Style Guide (SG)
- [x] Spacing adhere's to the SG 
- [x] Naming adhere's to the SG
- [x] All other aspects of the SG are adhered to, or exceptions are justified in this pull request

Code Craftsmanship:

- [x] I've made an attempt to remove all redundant code
- [x] I've considered ways in which my changes might impact existing code, and cleaned it up
- [x] I've formatted the code in an effort to make it easier to read (proper error handling, function use, etc...)
- [x] I've commented appropriately where code is tricky
- [x] I agree that there is no "throw-away" code, and that code in this PR is of high quality: **1. vkernel scheduling still needs to be fixed. 2. ubenchmark tests needs to change to use finite budgets. 3. Time/Cycles approximations needs to be revisited for accuracy fixes.**