### PR TITLE
Bug fixes related to tcap_delegate and a fix for cos_rcv/cos_sched_rcv

### DIFF
--- a/src/components/lib/cos_kernel_api.c
+++ b/src/components/lib/cos_kernel_api.c
@@ -787,7 +787,7 @@ cos_tcap_transfer(arcvcap_t dst, tcap_t src, tcap_res_t res, tcap_prio_t prio)
 int
 cos_tcap_delegate(asndcap_t dst, tcap_t src, tcap_res_t res, tcap_prio_t prio, tcap_deleg_flags_t flags)
 {
-	u32_t yield     = flags & TCAP_DELEG_YIELD;
+	u32_t yield     = (flags && TCAP_DELEG_YIELD);
 	/* top bit is if we are dispatching or not */
 	int prio_higher = (u32_t)(prio >> 32) | (yield << ((sizeof(yield)*8)-1));
 	int prio_lower  = (u32_t)((prio << 32) >> 32);


### PR DESCRIPTION
### Summary of this PR

Fixed YIELD flag detection in cos_kernel_api and return from syscall handler after TCAP_DELEGATE. 
Also fixed cos_rcv/cos_sched_rcv return value (which was missed in previous PR). 

### Code Quality

As part of this pull request, I've considered the following:

Style:

- [x] Comments adhere to the Style Guide (SG)
- [x] Spacing adhere's to the SG 
- [x] Naming adhere's to the SG
- [x] All other aspects of the SG are adhered to, or exceptions are justified in this pull request

Code Craftsmanship:

- [x] I've made an attempt to remove all redundant code
- [x] I've considered ways in which my changes might impact existing code, and cleaned it up
- [x] I've formatted the code in an effort to make it easier to read (proper error handling, function use, etc...)
- [x] I've commented appropriately where code is tricky
- [x] I agree that there is no "throw-away" code, and that code in this PR is of high quality

