### PR TITLE
Bug fixes in cos_tcap_delegate/cos_rcv API, simple working vkernel scheduling with tcaps

### DIFF
--- a/src/components/implementation/no_interface/vkernel/micro_booter.c
+++ b/src/components/implementation/no_interface/vkernel/micro_booter.c
@@ -49,7 +49,7 @@ vm_init(void *d)
 			  (vaddr_t)cos_get_heap_ptr(), VM_CAPTBL_FREE, &booter_info);
 
 	PRINTC("Micro Booter started.\n");
-	test_run();
+	test_run_vk();
 	PRINTC("Micro Booter done.\n");
 
 	EXIT();

--- a/src/components/implementation/no_interface/vkernel/micro_booter.h
+++ b/src/components/implementation/no_interface/vkernel/micro_booter.h
@@ -46,6 +46,6 @@ tls_set(size_t off, unsigned long val)
 
 extern int prints(char *s);
 extern int printc(char *fmt, ...);
-extern void test_run(void);
+extern void test_run_vk(void);
 
 #endif /* MICRO_BOOTER_H */

--- a/src/components/implementation/no_interface/vkernel/vk_types.h
+++ b/src/components/implementation/no_interface/vkernel/vk_types.h
@@ -12,4 +12,7 @@ enum vm_captbl_layout {
 #define VM_COUNT        2	/* virtual machine count */
 #define VM_UNTYPED_SIZE (1<<26) /* untyped memory per vm = 64MB */
 
+#define VM_BUDGET_FIXED 400000
+#define VM_PRIO_FIXED   TCAP_PRIO_MAX
+
 #endif /* VK_TYPES_H */

--- a/src/components/implementation/no_interface/vkernel/vkernel.c
+++ b/src/components/implementation/no_interface/vkernel/vkernel.c
@@ -64,7 +64,9 @@ scheduler(void)
 		
 		if (vmx_info[index].initthd) {
 			assert(vk_info.vminitasnd[index]);
-			cos_asnd(vk_info.vminitasnd[index]);
+
+			if (cos_tcap_delegate(vk_info.vminitasnd[index], BOOT_CAPTBL_SELF_INITTCAP_BASE,
+					      TCAP_RES_INF, TCAP_PRIO_MAX, TCAP_DELEG_YIELD)) assert(0);
 		}
 	}
 }

--- a/src/components/implementation/no_interface/vkernel/vkernel.c
+++ b/src/components/implementation/no_interface/vkernel/vkernel.c
@@ -9,6 +9,7 @@
 #define PRINT_FN prints
 #define debug_print(str) (PRINT_FN(str __FILE__ ":" STR(__LINE__) ".\n"))
 #define BUG() do { debug_print("BUG @ "); *((int *)0) = 0; } while (0);
+#define SPIN() do { while (1) ; } while (0)
 
 struct vms_info {
 	struct cos_compinfo cinfo;
@@ -35,9 +36,7 @@ struct cos_compinfo *vk_cinfo = (struct cos_compinfo *)&vk_info.cinfo;
 
 void
 vk_terminate(void *d)
-{
-	BUG();
-}
+{ SPIN(); }
 
 void
 vm_exit(void *d)
@@ -59,15 +58,16 @@ scheduler(void)
 	int index;
 
 	while (ready_vms) {
-		cos_sched_rcv(BOOT_CAPTBL_SELF_INITRCV_BASE, &tid, &rcving, &cycles);
 		index = i++ % VM_COUNT;
 		
 		if (vmx_info[index].initthd) {
 			assert(vk_info.vminitasnd[index]);
 
 			if (cos_tcap_delegate(vk_info.vminitasnd[index], BOOT_CAPTBL_SELF_INITTCAP_BASE,
-					      TCAP_RES_INF, TCAP_PRIO_MAX, TCAP_DELEG_YIELD)) assert(0);
+					      VM_BUDGET_FIXED, VM_PRIO_FIXED, TCAP_DELEG_YIELD)) assert(0);
 		}
+
+		while (cos_sched_rcv(BOOT_CAPTBL_SELF_INITRCV_BASE, &tid, &rcving, &cycles)) ;
 	}
 }
 
@@ -151,9 +151,6 @@ cos_init(void)
 
 		vm_info->initrcv = cos_arcv_alloc(vk_cinfo, vm_info->initthd, vm_info->inittcap, vk_cinfo->comp_cap, BOOT_CAPTBL_SELF_INITRCV_BASE);
 		assert(vm_info->initrcv);
-
-		ret = cos_tcap_transfer(vm_info->initrcv, BOOT_CAPTBL_SELF_INITTCAP_BASE, TCAP_RES_INF, TCAP_PRIO_MAX);
-		assert(ret == 0);
 
 		ret = cos_cap_cpy_at(vm_cinfo, BOOT_CAPTBL_SELF_INITTCAP_BASE, vk_cinfo, vm_info->inittcap);
 		assert(ret == 0);

--- a/src/components/implementation/tests/micro_booter/mb_tests.c
+++ b/src/components/implementation/tests/micro_booter/mb_tests.c
@@ -596,8 +596,9 @@ test_captbl_expand(void)
 	PRINTC("Captbl expand SUCCESS.\n");
 }
 
+/* Executed in micro_booter environment */
 void
-test_run(void)
+test_run_mb(void)
 {
 	test_timer();
 	test_budgets();
@@ -609,6 +610,28 @@ test_run(void)
 
 	test_async_endpoints();
 	test_async_endpoints_perf();
+
+	test_inv();
+	test_inv_perf();
+
+	test_captbl_expand();
+}
+
+/*
+ * Executed in vkernel environment:
+ *  Some of the tests are not feasible at least for now 
+ *  to run in vkernel env. (ex: tcaps related, because budgets 
+ *  in these tests are INF. 
+ *
+ * TODO: Fix those eventually.
+ */
+void
+test_run_vk(void)
+{
+	test_thds();
+	test_thds_perf();
+
+	test_mem();
 
 	test_inv();
 	test_inv_perf();

--- a/src/components/implementation/tests/micro_booter/micro_booter.c
+++ b/src/components/implementation/tests/micro_booter/micro_booter.c
@@ -38,7 +38,7 @@ int num = 1, den = 0;
 
 void
 term_fn(void *d)
-{ BUG_DIVZERO(); }
+{ SPIN(); }
 
 void
 cos_init(void)
@@ -56,7 +56,7 @@ cos_init(void)
 	printc("\t%d cycles per microsecond\n", cycs);
 
 	PRINTC("\nMicro Booter started.\n");
-	test_run();
+	test_run_mb();
 	PRINTC("\nMicro Booter done.\n");
 
 	cos_thd_switch(termthd);

--- a/src/components/implementation/tests/micro_booter/micro_booter.h
+++ b/src/components/implementation/tests/micro_booter/micro_booter.h
@@ -13,6 +13,7 @@
 #define debug_print(str) (PRINT_FN(str __FILE__ ":" STR(__LINE__) ".\n"))
 #define BUG() do { debug_print("BUG @ "); *((int *)0) = 0; } while (0);
 #define BUG_DIVZERO() do { debug_print("Testing divide by zero fault @ "); int i = num / den; } while (0);
+#define SPIN() do { while (1) ; } while (0)
 
 #include <cos_component.h>
 #include <cobj_format.h>
@@ -43,6 +44,6 @@ tls_set(size_t off, unsigned long val)
 
 extern int prints(char *s);
 extern int printc(char *fmt, ...);
-extern void test_run(void);
+extern void test_run_mb(void);
 
 #endif /* MICRO_BOOTER_H */

--- a/src/components/lib/cos_kernel_api.c
+++ b/src/components/lib/cos_kernel_api.c
@@ -787,7 +787,7 @@ cos_tcap_transfer(arcvcap_t dst, tcap_t src, tcap_res_t res, tcap_prio_t prio)
 int
 cos_tcap_delegate(asndcap_t dst, tcap_t src, tcap_res_t res, tcap_prio_t prio, tcap_deleg_flags_t flags)
 {
-	u32_t yield     = flags & TCAP_DELEG_YIELD;
+	u32_t yield     = ((flags & TCAP_DELEG_YIELD) != 0);
 	/* top bit is if we are dispatching or not */
 	int prio_higher = (u32_t)(prio >> 32) | (yield << ((sizeof(yield)*8)-1));
 	int prio_lower  = (u32_t)((prio << 32) >> 32);

--- a/src/kernel/capinv.c
+++ b/src/kernel/capinv.c
@@ -483,7 +483,8 @@ cap_thd_switch(struct pt_regs *regs, struct thread *curr, struct thread  *next,
 		assert(!(next->state & THD_STATE_PREEMPTED));
 		next->state &= ~THD_STATE_RCVING;
 		thd_state_evt_deliver(next, &a, &b);
-		__userregs_setretvals(&next->regs, thd_rcvcap_pending_dec(next), a, b);
+		thd_rcvcap_pending_dec(next);
+		__userregs_setretvals(&next->regs, thd_rcvcap_pending(next), a, b);
 	}
 
 	copy_all_regs(&next->regs, regs);
@@ -870,13 +871,16 @@ composite_syscall_handler(struct pt_regs *regs)
 
 	/* slowpath restbl (captbl and pgtbl) operations */
 	ret = composite_syscall_slowpath(regs, &thd_switch);
+	if (ret < 0) cos_throw(done, ret);
+
+	if (thd_switch) return ret; 
 done:
 	/*
 	 * Note: we need to return ret to user-level (e.g. as a return
 	 * value), which is not the return value of this function.
 	 * Thus the level of indirection here.
 	 */
-	if (!thd_switch) __userregs_set(regs, ret, __userregs_getsp(regs), __userregs_getip(regs));
+	__userregs_set(regs, ret, __userregs_getsp(regs), __userregs_getip(regs));
 
 	return 0;
 }
@@ -1442,6 +1446,8 @@ composite_syscall_slowpath(struct pt_regs *regs, int *thd_switch)
 			n = asnd_process(rthd, thd, tcapdst, tcap_current(cos_info), &tcap_next, yield);
 			if (n != thd) {
 				ret = cap_switch(regs, thd, n, tcap_next, TCAP_TIME_NIL, ci, cos_info);
+				if (unlikely(ret < 0)) cos_throw(err, ret);
+
 				*thd_switch = 1;
 			}
 


### PR DESCRIPTION
### Summary of this PR

1. Fixed a bug in cos_tcap_delegate for setting yield flag. 
2. Fixed return value of cos_rcv from kernel to include pending for sched queue.
3. Working simple scheduling in vkernel using cos_tcap_delegate with fixed budgets for all vms. 
4. Had to eliminate some of the tests that aren't feasible to run vkernel yet. 
5. Replaced the obvious BUG*() from Termination threads in vkernel and micro_booter with a SPIN() to avoid unnecessary dump that could overwrite useful logging information on baremetal.

### Code Quality

As part of this pull request, I've considered the following:

Style:

- [x] Comments adhere to the Style Guide (SG)
- [x] Spacing adhere's to the SG 
- [x] Naming adhere's to the SG
- [x] All other aspects of the SG are adhered to, or exceptions are justified in this pull request

Code Craftsmanship:

- [x] I've made an attempt to remove all redundant code
- [x] I've considered ways in which my changes might impact existing code, and cleaned it up
- [x] I've formatted the code in an effort to make it easier to read (proper error handling, function use, etc...)
- [x] I've commented appropriately where code is tricky
- [x] I agree that there is no "throw-away" code, and that code in this PR is of high quality: **any such code that needs further work has FIXME/TODO comments around it**
