### PR TITLE
Notify scheduler if thread in `rcving` has `pending` events

### DIFF
--- a/src/components/implementation/no_interface/vkernel/vkernel.c
+++ b/src/components/implementation/no_interface/vkernel/vkernel.c
@@ -53,7 +53,7 @@ scheduler(void)
 {
 	static unsigned int i;
 	thdid_t tid;
-	int rcving;
+	int rcving, vm_pending;
 	cycles_t cycles;
 	int index;
 
@@ -67,7 +67,7 @@ scheduler(void)
 					      VM_BUDGET_FIXED, VM_PRIO_FIXED, TCAP_DELEG_YIELD)) assert(0);
 		}
 
-		while (cos_sched_rcv(BOOT_CAPTBL_SELF_INITRCV_BASE, &tid, &rcving, &cycles)) ;
+		while (cos_sched_rcv(BOOT_CAPTBL_SELF_INITRCV_BASE, &tid, &rcving, &vm_pending, &cycles)) ;
 	}
 }
 

--- a/src/components/include/cos_kernel_api.h
+++ b/src/components/include/cos_kernel_api.h
@@ -83,7 +83,7 @@ int cos_asnd(asndcap_t snd);
 /* returns non-zero if there are still pending events (i.e. there have been pending snds) */
 int cos_rcv(arcvcap_t rcv);
 /* returns the same value as cos_rcv, but also information about scheduling events */
-int cos_sched_rcv(arcvcap_t rcv, thdid_t *thdid, int *rcving, cycles_t *cycles);
+int cos_sched_rcv(arcvcap_t rcv, thdid_t *thdid, int *rcving, int *pending, cycles_t *cycles);
 
 int cos_introspect(struct cos_compinfo *ci, capid_t cap, unsigned long op);
 

--- a/src/components/lib/cos_kernel_api.c
+++ b/src/components/lib/cos_kernel_api.c
@@ -658,7 +658,7 @@ cos_asnd(asndcap_t snd)
 { return call_cap_op(snd, 0, 0, 0, 0, 0); }
 
 int
-cos_sched_rcv(arcvcap_t rcv, thdid_t *thdid, int *receiving, cycles_t *cycles)
+cos_sched_rcv(arcvcap_t rcv, thdid_t *thdid, int *receiving, int *pending, cycles_t *cycles)
 {
 	unsigned long thd_state = 0;
 	unsigned long cyc = 0;
@@ -667,6 +667,7 @@ cos_sched_rcv(arcvcap_t rcv, thdid_t *thdid, int *receiving, cycles_t *cycles)
 	ret = call_cap_retvals_asm(rcv, 0, 0, 0, 0, 0, &thd_state, &cyc);
 
 	*receiving = (int)(thd_state >> (sizeof(thd_state)*8-1));
+	*pending = (int)((thd_state << 1) >> (sizeof(thd_state)*8-1));
 	*thdid = (thdid_t)(thd_state & ((1 << (sizeof(thdid_t)*8))-1));
 	*cycles = cyc;
 
@@ -679,9 +680,10 @@ cos_rcv(arcvcap_t rcv)
 	thdid_t tid = 0;
 	int rcving;
 	cycles_t cyc;
+	int pending;
 	int ret;
 
-	ret = cos_sched_rcv(rcv, &tid, &rcving, &cyc);
+	ret = cos_sched_rcv(rcv, &tid, &rcving, &pending, &cyc);
 	assert(tid == 0);
 
 	return ret;

--- a/src/kernel/include/thd.h
+++ b/src/kernel/include/thd.h
@@ -177,21 +177,6 @@ thd_rcvcap_evt_dequeue(struct thread *head) { return list_dequeue(&head->event_h
 static inline int
 thd_track_exec(struct thread *t) { return !list_empty(&t->event_list); }
 
-static inline int
-thd_state_evt_deliver(struct thread *t, unsigned long *thd_state, unsigned long *cycles)
-{
-	struct thread *e = thd_rcvcap_evt_dequeue(t);
-
-	assert(thd_bound2rcvcap(t));
-	if (!e) return 0;
-
-	*thd_state = e->tid | (e->state & THD_STATE_RCVING ? 1<<31 : 0);
-	*cycles    = e->exec;
-	e->exec    = 0;
-
-	return 1;
-}
-
 static int
 thd_rcvcap_pending(struct thread *t)
 { return t->rcvcap.pending || list_first(&t->event_head) != NULL; }
@@ -209,6 +194,21 @@ thd_rcvcap_pending_dec(struct thread *arcvt)
 	arcvt->rcvcap.pending--;
 
 	return pending;
+}
+
+static inline int
+thd_state_evt_deliver(struct thread *t, unsigned long *thd_state, unsigned long *cycles)
+{
+	struct thread *e = thd_rcvcap_evt_dequeue(t);
+
+	assert(thd_bound2rcvcap(t));
+	if (!e) return 0;
+
+	*thd_state = e->tid | (e->state & THD_STATE_RCVING ? 1<<31 : 0) | ((thd_bound2rcvcap(e) && thd_rcvcap_pending(e)) ? 1<<30 : 0);
+	*cycles    = e->exec;
+	e->exec    = 0;
+
+	return 1;
 }
 
 static int


### PR DESCRIPTION
### Summary of this PR

`cos_sched_rcv` to receive notifications and if the scheduling event has `pending` events, a temporary change, so that scheduler gets to decide whether to run the thread that is `rcving`. More info in #198 

### Code Quality

As part of this pull request, I've considered the following:

Style:

- [x] Comments adhere to the Style Guide (SG)
- [x] Spacing adhere's to the SG 
- [x] Naming adhere's to the SG
- [x] All other aspects of the SG are adhered to, or exceptions are justified in this pull request

Code Craftsmanship:

- [x] I've made an attempt to remove all redundant code
- [x] I've considered ways in which my changes might impact existing code, and cleaned it up
- [x] I've formatted the code in an effort to make it easier to read (proper error handling, function use, etc...)
- [x] I've commented appropriately where code is tricky
- [x] I agree that there is no "throw-away" code, and that code in this PR is of high quality: This is a temporary fix to a problem described in issue #198 