### PR TITLE
Notification type changed to indicate blocked/unblocked

### DIFF
--- a/src/components/implementation/no_interface/vkernel/vkernel.c
+++ b/src/components/implementation/no_interface/vkernel/vkernel.c
@@ -53,7 +53,7 @@ scheduler(void)
 {
 	static unsigned int i;
 	thdid_t tid;
-	int rcving;
+	int blocked;
 	cycles_t cycles;
 	int index;
 
@@ -67,7 +67,7 @@ scheduler(void)
 					      VM_BUDGET_FIXED, VM_PRIO_FIXED, TCAP_DELEG_YIELD)) assert(0);
 		}
 
-		while (cos_sched_rcv(BOOT_CAPTBL_SELF_INITRCV_BASE, &tid, &rcving, &cycles)) ;
+		while (cos_sched_rcv(BOOT_CAPTBL_SELF_INITRCV_BASE, &tid, &blocked, &cycles)) ;
 	}
 }
 

--- a/src/components/implementation/no_interface/vkernel/vkernel.c
+++ b/src/components/implementation/no_interface/vkernel/vkernel.c
@@ -52,10 +52,10 @@ void
 scheduler(void) 
 {
 	static unsigned int i;
-	thdid_t tid;
-	int blocked;
-	cycles_t cycles;
-	int index;
+	thdid_t             tid;
+	int                 blocked;
+	cycles_t            cycles;
+	int                 index;
 
 	while (ready_vms) {
 		index = i++ % VM_COUNT;

--- a/src/components/implementation/tests/micro_booter/mb_tests.c
+++ b/src/components/implementation/tests/micro_booter/mb_tests.c
@@ -164,17 +164,17 @@ async_thd_parent(void *thdcap)
 	thdcap_t  tc = (thdcap_t)thdcap;
 	arcvcap_t rc = rcp_global;
 	asndcap_t sc = scp_global;
-	int ret, pending;
-	thdid_t tid;
-	int blocked;
-	cycles_t cycles;
+	int       ret, pending;
+	thdid_t   tid;
+	int       blocked;
+	cycles_t  cycles;
 
 	PRINTC("--> sending\n");
-	ret = cos_asnd(sc);
+	ret     = cos_asnd(sc);
 	if (ret) PRINTC("asnd returned %d.\n", ret);
 	PRINTC("--> Back in the asnder.\n");
 	PRINTC("--> sending\n");
-	ret = cos_asnd(sc);
+	ret     = cos_asnd(sc);
 	if (ret) PRINTC("--> asnd returned %d.\n", ret);
 	PRINTC("--> Back in the asnder.\n");
 	PRINTC("--> receiving to get notifications\n");
@@ -338,7 +338,7 @@ cycles_t cyc_per_usec;
 static void
 test_timer(void)
 {
-	int i;
+	int      i;
 	thdcap_t tc;
 	cycles_t c = 0, p = 0, t = 0;
 
@@ -347,15 +347,15 @@ test_timer(void)
 	tc = cos_thd_alloc(&booter_info, booter_info.comp_cap, spinner, NULL);
 
 	for (i = 0 ; i <= 16 ; i++) {
-		thdid_t  tid;
-		int      blocked;
-		cycles_t cycles, now;
+		thdid_t     tid;
+		int         blocked;
+		cycles_t    cycles, now;
 		tcap_time_t timer;
 
 		rdtscll(now);
 		timer = tcap_cyc2time(now + 1000 * cyc_per_usec);
 		cos_switch(tc, BOOT_CAPTBL_SELF_INITTCAP_BASE, 0, timer, BOOT_CAPTBL_SELF_INITRCV_BASE);
-		p = c;
+		p     = c;
 		rdtscll(c);
 		if (i > 0) t += c-p;
 
@@ -453,13 +453,13 @@ test_budgets_multi(void)
 	PRINTC("Budget switch latencies:\n");
 	for (i = 1 ; i < 10 ; i++) {
 		tcap_res_t res;
-		thdid_t  tid;
-		int      blocked;
-		cycles_t cycles, s, e;
+		thdid_t    tid;
+		int        blocked;
+		cycles_t   cycles, s, e;
 
 		/* test both increasing budgets and constant budgets */
 		if (i > 5) res = 1600000;
-		else res = i * 800000;
+		else       res = i * 800000;
 
 		if (cos_tcap_transfer(mbt.p.rc, BOOT_CAPTBL_SELF_INITTCAP_BASE, res, TCAP_PRIO_MAX + 2)) assert(0);
 		if (cos_tcap_transfer(mbt.c.rc, mbt.p.tcc, res/2, TCAP_PRIO_MAX + 2)) assert(0);

--- a/src/components/implementation/tests/micro_booter/mb_tests.c
+++ b/src/components/implementation/tests/micro_booter/mb_tests.c
@@ -141,9 +141,6 @@ async_thd_fn(void *thdcap)
 {
 	thdcap_t tc = (thdcap_t)thdcap;
 	arcvcap_t rc = rcc_global;
-	thdid_t tid;
-	int rcving;
-	cycles_t cycles;
 	int pending;
 
 	PRINTC("Asynchronous event thread handler.\n");
@@ -169,7 +166,7 @@ async_thd_parent(void *thdcap)
 	asndcap_t sc = scp_global;
 	int ret, pending;
 	thdid_t tid;
-	int rcving;
+	int blocked;
 	cycles_t cycles;
 
 	PRINTC("--> sending\n");
@@ -181,8 +178,8 @@ async_thd_parent(void *thdcap)
 	if (ret) PRINTC("--> asnd returned %d.\n", ret);
 	PRINTC("--> Back in the asnder.\n");
 	PRINTC("--> receiving to get notifications\n");
-	pending = cos_sched_rcv(rc, &tid, &rcving, &cycles);
-	PRINTC("--> pending %d, thdid %d, rcving %d, cycles %lld\n", pending, tid, rcving, cycles);
+	pending = cos_sched_rcv(rc, &tid, &blocked, &cycles);
+	PRINTC("--> pending %d, thdid %d, blocked %d, cycles %lld\n", pending, tid, blocked, cycles);
 
 	async_test_flag = 0;
 	while (1) cos_thd_switch(tc);
@@ -351,7 +348,7 @@ test_timer(void)
 
 	for (i = 0 ; i <= 16 ; i++) {
 		thdid_t  tid;
-		int      rcving;
+		int      blocked;
 		cycles_t cycles, now;
 		tcap_time_t timer;
 
@@ -363,7 +360,7 @@ test_timer(void)
 		if (i > 0) t += c-p;
 
 		/* FIXME: we should avoid calling this two times in the common case, return "more evts" */
-		while (cos_sched_rcv(BOOT_CAPTBL_SELF_INITRCV_BASE, &tid, &rcving, &cycles) != 0) ;
+		while (cos_sched_rcv(BOOT_CAPTBL_SELF_INITRCV_BASE, &tid, &blocked, &cycles) != 0) ;
 	}
 
 	PRINTC("\tCycles per tick (1000 microseconds) = %lld\n", t/16);
@@ -426,7 +423,7 @@ test_budgets_single(void)
 	for (i = 1 ; i < 10 ; i++) {
 		cycles_t s, e;
 		thdid_t  tid;
-		int      rcving;
+		int      blocked;
 		cycles_t cycles;
 
 		if (cos_tcap_transfer(bt.c.rc, BOOT_CAPTBL_SELF_INITTCAP_BASE, i * 100000, TCAP_PRIO_MAX + 2)) assert(0);
@@ -437,7 +434,7 @@ test_budgets_single(void)
 		PRINTC("%lld,\t", e-s);
 
 		/* FIXME: we should avoid calling this two times in the common case, return "more evts" */
-		while (cos_sched_rcv(BOOT_CAPTBL_SELF_INITRCV_BASE, &tid, &rcving, &cycles) != 0) ;
+		while (cos_sched_rcv(BOOT_CAPTBL_SELF_INITRCV_BASE, &tid, &blocked, &cycles) != 0) ;
 	}
 	PRINTC("Done.\n");
 }
@@ -457,7 +454,7 @@ test_budgets_multi(void)
 	for (i = 1 ; i < 10 ; i++) {
 		tcap_res_t res;
 		thdid_t  tid;
-		int      rcving;
+		int      blocked;
 		cycles_t cycles, s, e;
 
 		/* test both increasing budgets and constant budgets */
@@ -473,7 +470,7 @@ test_budgets_multi(void)
 		rdtscll(e);
 		PRINTC("g:%llu c:%llu p:%llu => %llu,\t", mbt.g.cyc - s, mbt.c.cyc - s, mbt.p.cyc - s, e - s);
 
-		cos_sched_rcv(BOOT_CAPTBL_SELF_INITRCV_BASE, &tid, &rcving, &cycles);
+		cos_sched_rcv(BOOT_CAPTBL_SELF_INITRCV_BASE, &tid, &blocked, &cycles);
 		PRINTC("%d=%llu\n", tid, cycles);
 	}
 	PRINTC("Done.\n");

--- a/src/components/include/cos_kernel_api.h
+++ b/src/components/include/cos_kernel_api.h
@@ -83,7 +83,7 @@ int cos_asnd(asndcap_t snd);
 /* returns non-zero if there are still pending events (i.e. there have been pending snds) */
 int cos_rcv(arcvcap_t rcv);
 /* returns the same value as cos_rcv, but also information about scheduling events */
-int cos_sched_rcv(arcvcap_t rcv, thdid_t *thdid, int *rcving, cycles_t *cycles);
+int cos_sched_rcv(arcvcap_t rcv, thdid_t *thdid, int *blocked, cycles_t *cycles);
 
 int cos_introspect(struct cos_compinfo *ci, capid_t cap, unsigned long op);
 

--- a/src/components/lib/cos_kernel_api.c
+++ b/src/components/lib/cos_kernel_api.c
@@ -661,14 +661,14 @@ int
 cos_sched_rcv(arcvcap_t rcv, thdid_t *thdid, int *blocked, cycles_t *cycles)
 {
 	unsigned long thd_state = 0;
-	unsigned long cyc = 0;
-	int ret;
+	unsigned long cyc       = 0;
+	int           ret;
 
-	ret = call_cap_retvals_asm(rcv, 0, 0, 0, 0, 0, &thd_state, &cyc);
+	ret      = call_cap_retvals_asm(rcv, 0, 0, 0, 0, 0, &thd_state, &cyc);
 
 	*blocked = (int)(thd_state >> (sizeof(thd_state)*8-1));
-	*thdid = (thdid_t)(thd_state & ((1 << (sizeof(thdid_t)*8))-1));
-	*cycles = cyc;
+	*thdid   = (thdid_t)(thd_state & ((1 << (sizeof(thdid_t)*8))-1));
+	*cycles  = cyc;
 
 	return ret;
 }
@@ -676,10 +676,10 @@ cos_sched_rcv(arcvcap_t rcv, thdid_t *thdid, int *blocked, cycles_t *cycles)
 int
 cos_rcv(arcvcap_t rcv)
 {
-	thdid_t tid = 0;
-	int blocked;
+	thdid_t  tid = 0;
+	int      blocked;
 	cycles_t cyc;
-	int ret;
+	int      ret;
 
 	ret = cos_sched_rcv(rcv, &tid, &blocked, &cyc);
 	assert(tid == 0);

--- a/src/components/lib/cos_kernel_api.c
+++ b/src/components/lib/cos_kernel_api.c
@@ -658,7 +658,7 @@ cos_asnd(asndcap_t snd)
 { return call_cap_op(snd, 0, 0, 0, 0, 0); }
 
 int
-cos_sched_rcv(arcvcap_t rcv, thdid_t *thdid, int *receiving, cycles_t *cycles)
+cos_sched_rcv(arcvcap_t rcv, thdid_t *thdid, int *blocked, cycles_t *cycles)
 {
 	unsigned long thd_state = 0;
 	unsigned long cyc = 0;
@@ -666,7 +666,7 @@ cos_sched_rcv(arcvcap_t rcv, thdid_t *thdid, int *receiving, cycles_t *cycles)
 
 	ret = call_cap_retvals_asm(rcv, 0, 0, 0, 0, 0, &thd_state, &cyc);
 
-	*receiving = (int)(thd_state >> (sizeof(thd_state)*8-1));
+	*blocked = (int)(thd_state >> (sizeof(thd_state)*8-1));
 	*thdid = (thdid_t)(thd_state & ((1 << (sizeof(thdid_t)*8))-1));
 	*cycles = cyc;
 
@@ -677,11 +677,11 @@ int
 cos_rcv(arcvcap_t rcv)
 {
 	thdid_t tid = 0;
-	int rcving;
+	int blocked;
 	cycles_t cyc;
 	int ret;
 
-	ret = cos_sched_rcv(rcv, &tid, &rcving, &cyc);
+	ret = cos_sched_rcv(rcv, &tid, &blocked, &cyc);
 	assert(tid == 0);
 
 	return ret;

--- a/src/kernel/include/thd.h
+++ b/src/kernel/include/thd.h
@@ -177,21 +177,6 @@ thd_rcvcap_evt_dequeue(struct thread *head) { return list_dequeue(&head->event_h
 static inline int
 thd_track_exec(struct thread *t) { return !list_empty(&t->event_list); }
 
-static inline int
-thd_state_evt_deliver(struct thread *t, unsigned long *thd_state, unsigned long *cycles)
-{
-	struct thread *e = thd_rcvcap_evt_dequeue(t);
-
-	assert(thd_bound2rcvcap(t));
-	if (!e) return 0;
-
-	*thd_state = e->tid | (e->state & THD_STATE_RCVING ? 1<<31 : 0);
-	*cycles    = e->exec;
-	e->exec    = 0;
-
-	return 1;
-}
-
 static int
 thd_rcvcap_pending(struct thread *t)
 { return t->rcvcap.pending || list_first(&t->event_head) != NULL; }
@@ -209,6 +194,21 @@ thd_rcvcap_pending_dec(struct thread *arcvt)
 	arcvt->rcvcap.pending--;
 
 	return pending;
+}
+
+static inline int
+thd_state_evt_deliver(struct thread *t, unsigned long *thd_state, unsigned long *cycles)
+{
+	struct thread *e = thd_rcvcap_evt_dequeue(t);
+
+	assert(thd_bound2rcvcap(t));
+	if (!e) return 0;
+
+	*thd_state = e->tid | (e->state & THD_STATE_RCVING ? (thd_rcvcap_pending(e) ? 0 : 1<<31) : 0);
+	*cycles    = e->exec;
+	e->exec    = 0;
+
+	return 1;
 }
 
 static int


### PR DESCRIPTION
### Summary of this PR

cos_sched_rcv will be notified if the thread is BLOCKED(RCVING and has no events pending) or not as opposed to whether the thread state is RCVING.
And indentation cleanup in the code-paths encountered in this PR. 

For more info on the notification change, look at issue #198 

### Code Quality

As part of this pull request, I've considered the following:

Style:

- [x] Comments adhere to the Style Guide (SG)
- [x] Spacing adhere's to the SG 
- [x] Naming adhere's to the SG
- [x] All other aspects of the SG are adhered to, or exceptions are justified in this pull request

Code Craftsmanship:

- [x] I've made an attempt to remove all redundant code
- [x] I've considered ways in which my changes might impact existing code, and cleaned it up
- [x] I've formatted the code in an effort to make it easier to read (proper error handling, function use, etc...)
- [x] I've commented appropriately where code is tricky
- [x] I agree that there is no "throw-away" code, and that code in this PR is of high quality: look at issue #198 