### PR TITLE
APIC Timer Support

### DIFF
--- a/src/kernel/include/shared/cos_types.h
+++ b/src/kernel/include/shared/cos_types.h
@@ -174,6 +174,7 @@ typedef enum {
 	HW_ID30,
 	HW_ID31,
 	HW_ID32,
+	HW_LAPIC_TIMER = 255,  /* Local APIC TSC-DEADLINE mode - Timer interrupts */
 } hwid_t;
 
 typedef unsigned long capid_t;

--- a/src/kernel/include/tcap.h
+++ b/src/kernel/include/tcap.h
@@ -205,7 +205,7 @@ tcap_timer_update(struct cos_cpu_local_info *cos_info, struct tcap *next, tcap_t
 	/* avoid the large costs of setting the timer hardware if possible */
 	if (cycles_same(cos_info->timeout_next, timer)) return;
 
-	chal_timer_set(timer - now);
+	chal_timer_set(timer);
 	cos_info->timeout_next = timer;
 }
 

--- a/src/platform/i386/Makefile
+++ b/src/platform/i386/Makefile
@@ -39,13 +39,14 @@ OBJS += vtxprintf.o
 OBJS += tss.o
 OBJS += user.o
 OBJS += serial.o
-OBJS += timer.o
+OBJS += hpet.o
 OBJS += chal.o
 OBJS += boot_comp.o
 OBJS += miniacpi.o
 #OBJS += console.o
 OBJS += vga.o
 OBJS += exception.o
+OBJS += lapic.o
 
 COS_OBJ += pgtbl.o
 COS_OBJ += retype_tbl.o

--- a/src/platform/i386/chal_cpu.h
+++ b/src/platform/i386/chal_cpu.h
@@ -68,9 +68,11 @@ extern void sysenter_entry(void);
 
 static inline void
 writemsr(u32_t reg, u32_t low, u32_t high)
-{
-	__asm__("wrmsr" : : "c"(reg), "a"(low), "d"(high));
-}
+{ __asm__("wrmsr" : : "c"(reg), "a"(low), "d"(high)); }
+
+static inline void
+readmsr(u32_t reg, u32_t *low, u32_t *high)
+{ __asm__("rdmsr" : "=a"(*low), "=d"(*high) : "c"(reg)); }
 
 static void
 chal_cpu_init(void)
@@ -108,5 +110,8 @@ chal_user_upcall(void *ip, u16_t tid, u16_t cpuid)
 
 void chal_timer_thd_init(struct thread *t);
 
+static inline void
+chal_cpuid(int code, u32_t *a, u32_t *b, u32_t *c, u32_t *d)
+{ asm volatile("cpuid" : "=a"(*a), "=b"(*b), "=c"(*c), "=d"(*d) : "0"(code)); }
 
 #endif /* CHAL_CPU_H */

--- a/src/platform/i386/entry.S
+++ b/src/platform/i386/entry.S
@@ -163,6 +163,7 @@ IRQ_ID(60)
 IRQ_ID(61)
 IRQ_ID(62)
 IRQ_ID(63)
+IRQ(lapic_timer)
 
 /*
  * Loads the IDT into the processor

--- a/src/platform/i386/hpet.c
+++ b/src/platform/i386/hpet.c
@@ -131,15 +131,32 @@ timer_calibration(void)
 {
 	static int   cnt = 0;
 	static u64_t cycle = 0, tot = 0, prev;
+	static u32_t apic_curr = 0, apic_tot = 0, apic_prev;
 
 	prev = cycle;
+	apic_prev = apic_curr;
 	rdtscll(cycle);
-	if (cnt) tot += cycle-prev;
+	apic_curr = lapic_get_ccr();
+	
+	if (cnt) {
+		tot += cycle-prev;
+		apic_tot += (apic_prev - apic_curr);
+	}
 	if (cnt >= TIMER_CALIBRATION_ITER) {
 		assert(hpetcyc_per_tick);
 		timer_calibration_init   = 0;
 		cycles_per_tick          = (unsigned long)(tot / TIMER_CALIBRATION_ITER);
 		assert(cycles_per_tick > hpetcyc_per_tick);
+
+		if (lapic_timer_calib_init) {
+			u32_t cycs_to_apic_ratio = 0, apic_cycs_per_tick = 0;
+
+			apic_cycs_per_tick = apic_tot / TIMER_CALIBRATION_ITER;
+			assert (apic_cycs_per_tick);
+
+			cycs_to_apic_ratio = cycles_per_tick / apic_cycs_per_tick;
+			lapic_timer_calibration(cycs_to_apic_ratio);
+		}
 
 		/* Possibly significant rounding error here.  Bound by the factor */
 		timer_cycles_per_hpetcyc = (TIMER_ERROR_BOUND_FACTOR * cycles_per_tick) / hpetcyc_per_tick;

--- a/src/platform/i386/hpet.c
+++ b/src/platform/i386/hpet.c
@@ -159,7 +159,7 @@ chal_cyc_usec(void)
 int
 periodic_handler(struct pt_regs *regs)
 {
-	int preempt;
+	int preempt = 1;
 
 	if (unlikely(timer_calibration_init)) timer_calibration();
 
@@ -212,12 +212,12 @@ timer_set(timer_type_t timer_type, u64_t cycles)
 }
 
 /* FIXME:  This is broken. Why does setting the oneshot twice make it work? */
-void
+/*void
 chal_timer_set(cycles_t cycles)
 {
 	timer_set(TIMER_ONESHOT, cycles);
 	timer_set(TIMER_ONESHOT, cycles);
-}
+}*/
 
 u64_t
 timer_find_hpet(void *timer)

--- a/src/platform/i386/idt.c
+++ b/src/platform/i386/idt.c
@@ -161,6 +161,7 @@ idt_init(void)
 	idt_set_gate(HW_ID30,         (u32_t)handler_hw_61, 0x08, 0x8E);
 	idt_set_gate(HW_ID31,         (u32_t)handler_hw_62, 0x08, 0x8E);
 	idt_set_gate(HW_ID32,         (u32_t)handler_hw_63, 0x08, 0x8E);
+	idt_set_gate(HW_LAPIC_TIMER,  (u32_t)lapic_timer_irq, 0x08, 0x8E);
 
 	struct {
 		unsigned short length;

--- a/src/platform/i386/isr.h
+++ b/src/platform/i386/isr.h
@@ -80,6 +80,7 @@ extern void handler_hw_60(struct pt_regs *);
 extern void handler_hw_61(struct pt_regs *);
 extern void handler_hw_62(struct pt_regs *);
 extern void handler_hw_63(struct pt_regs *);
+extern void lapic_timer_irq(struct pt_regs *);
 
 static void
 ack_irq(int n)

--- a/src/platform/i386/kernel.c
+++ b/src/platform/i386/kernel.c
@@ -164,6 +164,7 @@ kmain(struct multiboot *mboot, u32_t mboot_magic, u32_t esp)
 
 	kern_boot_comp();
 	timer_init();
+	lapic_timer_init();
 	kern_boot_upcall();
 	/* should not get here... */
 	khalt();

--- a/src/platform/i386/kernel.h
+++ b/src/platform/i386/kernel.h
@@ -55,6 +55,9 @@ u32_t lapic_find_localaddr(void *l);
 void lapic_set_page(u32_t page);
 void lapic_timer_init(void);
 void lapic_set_timer(int timer_type, cycles_t deadline);
+u32_t lapic_get_ccr(void);
+void lapic_timer_calibration(u32_t ratio);
+extern u32_t lapic_timer_calib_init;
 
 void tls_update(u32_t addr);
 

--- a/src/platform/i386/kernel.h
+++ b/src/platform/i386/kernel.h
@@ -50,6 +50,12 @@ void *acpi_find_timer(void);
 void acpi_set_rsdt_page(u32_t);
 void kern_paging_map_init(void *pa);
 
+void *acpi_find_apic(void);
+u32_t lapic_find_localaddr(void *l);
+void lapic_set_page(u32_t page);
+void lapic_timer_init(void);
+void lapic_set_timer(int timer_type, cycles_t deadline);
+
 void tls_update(u32_t addr);
 
 //void printk(const char *fmt, ...);

--- a/src/platform/i386/lapic.c
+++ b/src/platform/i386/lapic.c
@@ -17,13 +17,10 @@
 #define LAPIC_PERIODIC_MODE    (0x01 << 17)
 #define LAPIC_ONESHOT_MODE     (0x00 << 17)
 #define LAPIC_TSCDEADLINE_MODE (0x02 << 17)
-
 #define LAPIC_MASK (1<<15)
 
-#define IA32_MSR_TSC		0x00000010
 #define IA32_MSR_TSC_DEADLINE	0x000006e0
 
-#define TEST_DEADLINE 3400000
 #define RETRY_ITERS   3
 
 extern int timer_process(struct pt_regs *regs);
@@ -77,22 +74,15 @@ lapic_find_localaddr(void *l)
 
 static void
 lapic_write_reg(u32_t off, u32_t val)
-{
-	*(u32_t *)(lapic + off) = val;
-}
+{ *(u32_t *)(lapic + off) = val; }
 
 static void
 lapic_ack(void)
-{
-	if (lapic) 
-		lapic_write_reg(LAPIC_EOI_REG, 0);
-}
+{ if (lapic) lapic_write_reg(LAPIC_EOI_REG, 0); }
 
 static u32_t
 lapic_read_reg(u32_t off)
-{
-	return *(u32_t *)(lapic + off);
-}
+{ return *(u32_t *)(lapic + off); }
 
 void
 lapic_set_timer(int timer_type, cycles_t deadline)
@@ -109,8 +99,10 @@ retry:
 	writemsr(IA32_MSR_TSC_DEADLINE, (u32_t) ((deadline << 32) >> 32), (u32_t)(deadline >> 32));
 	readmsr(IA32_MSR_TSC_DEADLINE, &low, &high);
 	if (!low && !high) {
-		if (retries -- > 0)
+		retries --;
+		if (retries > 0) {
 			goto retry;
+		}
 		else {
 			printk("Something wrong.. Cannot program TSC-DEADLINE\n");
 			assert(0);
@@ -144,7 +136,7 @@ lapic_tscdeadline_supported(void)
 	u32_t a, b, c, d;
 
 	chal_cpuid(6, &a, &b, &c, &d);
-	if (a & (1 << 1)) printk("APIC Timer runs at Constant Rate!!\n");	
+	if (a & (1 << 1)) printk("LAPIC Timer runs at Constant Rate!!\n");	
 
 	chal_cpuid(1, &a, &b, &c, &d);
 	if (c & (1 << 24)) return 1;

--- a/src/platform/i386/lapic.c
+++ b/src/platform/i386/lapic.c
@@ -1,0 +1,175 @@
+#include "io.h"
+#include "kernel.h"
+#include "chal_cpu.h"
+#include "isr.h"
+
+#define APIC_DEFAULT_PHYS      0xfee00000
+#define APIC_HDR_LEN_OFF       0x04
+#define APIC_CNTRLR_ADDR_OFF   0x24
+
+#define LAPIC_SVI_REG          0x0F0
+#define LAPIC_EOI_REG          0x0B0
+#define LAPIC_TIMER_LVT_REG    0x320
+#define LAPIC_DIV_CONF_REG     0x3e0
+#define LAPIC_INIT_COUNT_REG   0x380
+#define LAPIC_CURR_COUNT_REG   0x390
+
+#define LAPIC_PERIODIC_MODE    (0x01 << 17)
+#define LAPIC_ONESHOT_MODE     (0x00 << 17)
+#define LAPIC_TSCDEADLINE_MODE (0x02 << 17)
+
+#define LAPIC_MASK (1<<15)
+
+#define IA32_MSR_TSC		0x00000010
+#define IA32_MSR_TSC_DEADLINE	0x000006e0
+
+#define TEST_DEADLINE 3400000
+#define RETRY_ITERS   3
+
+extern int timer_process(struct pt_regs *regs);
+
+enum lapic_timer_type {
+	ONESHOT = 0,
+	PERIODIC,
+	TSC_DEADLINE,
+};
+
+enum lapic_timer_div_by_config {
+	DIV_BY_2 = 0,
+	DIV_BY_4,
+	DIV_BY_8,
+	DIV_BY_16,
+	DIV_BY_32,
+	DIV_BY_64,
+	DIV_BY_128,
+	DIV_BY_1,
+};
+
+static volatile void *lapic = (void *)APIC_DEFAULT_PHYS;
+
+u32_t
+lapic_find_localaddr(void *l)
+{
+	u32_t i;
+	unsigned char sum = 0;
+	unsigned char *lapicaddr = l;
+	u32_t length = *(u32_t *)(lapicaddr + APIC_HDR_LEN_OFF);
+
+	printk("Initializing LAPIC @ %p\n", lapicaddr);
+
+	for (i = 0 ; i < length ; i ++) {
+		sum += lapicaddr[i];
+	}
+
+	if (sum == 0) {
+		u32_t addr = *(u32_t *)(lapicaddr + APIC_CNTRLR_ADDR_OFF);
+
+		printk("\tChecksum is OK\n");
+		lapic = (void *)(addr);
+		printk("\tlapic: %p\n", lapic); 
+
+		return addr;
+	}
+
+	printk("\tInvalid checksum (%d)\n", sum);
+	return 0;
+}
+
+static void
+lapic_write_reg(u32_t off, u32_t val)
+{
+	*(u32_t *)(lapic + off) = val;
+}
+
+static void
+lapic_ack(void)
+{
+	if (lapic) 
+		lapic_write_reg(LAPIC_EOI_REG, 0);
+}
+
+static u32_t
+lapic_read_reg(u32_t off)
+{
+	return *(u32_t *)(lapic + off);
+}
+
+void
+lapic_set_timer(int timer_type, cycles_t deadline)
+{	
+	u32_t high, low;
+	int retries = RETRY_ITERS;
+
+	if (timer_type != TSC_DEADLINE) {
+		printk("Mode not supported\n");
+		assert(0);
+	}
+
+retry:	
+	writemsr(IA32_MSR_TSC_DEADLINE, (u32_t) ((deadline << 32) >> 32), (u32_t)(deadline >> 32));
+	readmsr(IA32_MSR_TSC_DEADLINE, &low, &high);
+	if (!low && !high) {
+		if (retries -- > 0)
+			goto retry;
+		else {
+			printk("Something wrong.. Cannot program TSC-DEADLINE\n");
+			assert(0);
+		}
+	}
+}
+
+void
+lapic_set_page(u32_t page)
+{
+	lapic = (void *)(page * (1 << 22) | ((u32_t)lapic & ((1<<22)-1)));
+
+	printk("\tSet LAPIC @ %p\n", lapic);
+}
+
+int
+lapic_timer_handler(struct pt_regs *regs)
+{
+	int preempt = 1; 
+
+	lapic_ack();
+
+	preempt = timer_process(regs);
+
+	return preempt;
+}
+
+static int
+lapic_tscdeadline_supported(void)
+{
+	u32_t a, b, c, d;
+
+	chal_cpuid(6, &a, &b, &c, &d);
+	if (a & (1 << 1)) printk("APIC Timer runs at Constant Rate!!\n");	
+
+	chal_cpuid(1, &a, &b, &c, &d);
+	if (c & (1 << 24)) return 1;
+
+	return 0;
+}
+
+void
+chal_timer_set(cycles_t cycles)
+{ lapic_set_timer(TSC_DEADLINE, cycles); }
+
+void
+lapic_timer_init(void)
+{
+	u32_t low, high;
+
+	if (!lapic_tscdeadline_supported()) {
+		printk("can't do LAPIC TSC-DEADLINE Mode\n");
+
+		/* TODO: perhaps fallback to ONESHOT?? */
+		assert(0);
+	}
+	
+	/* Set the mode and vector */
+	lapic_write_reg(LAPIC_TIMER_LVT_REG, HW_LAPIC_TIMER | LAPIC_TSCDEADLINE_MODE);
+	/* Set the divisor */
+	lapic_write_reg(LAPIC_DIV_CONF_REG, DIV_BY_1);
+}

--- a/src/platform/i386/vm.c
+++ b/src/platform/i386/vm.c
@@ -91,6 +91,15 @@ kern_setup_image(void)
 			timer_set_hpet_page(j);
 			j++;
 		}
+
+		/* lapic memory map */
+		u32_t lapic = lapic_find_localaddr(acpi_find_apic());
+		if (lapic) {
+			page = round_up_to_pgd_page(lapic & 0xffffffff) - (1 << 22);
+			boot_comp_pgd[j] = page | PGTBL_PRESENT | PGTBL_WRITABLE | PGTBL_SUPER | PGTBL_GLOBAL;
+			lapic_set_page(j);
+			j ++;
+		}
 	}
 
 	for ( ; j < PAGE_SIZE/sizeof(unsigned int) ; i += PGD_RANGE, j++) {


### PR DESCRIPTION
### Summary of this PR

Added support for APIC Timers, Both ONESHOT and TSC-DEADLINE. If TSC-DEADLINE is not supported by the CPU, it falls back to ONESHOT mode. (PERIODIC mode not supported.)
Qemu-i386 2.0.0 doesn't support TSC-DEADLINE, so it uses ONESHOT mode. 

### Code Quality

As part of this pull request, I've considered the following:

Style:

- [x] Comments adhere to the Style Guide (SG)
- [x] Spacing adhere's to the SG 
- [x] Naming adhere's to the SG
- [x] All other aspects of the SG are adhered to, or exceptions are justified in this pull request

Code Craftsmanship:

- [x] I've made an attempt to remove all redundant code
- [x] I've considered ways in which my changes might impact existing code, and cleaned it up
- [x] I've formatted the code in an effort to make it easier to read (proper error handling, function use, etc...)
- [x] I've commented appropriately where code is tricky
- [x] I agree that there is no "throw-away" code, and that code in this PR is of high quality
