### PR TITLE
Avoid retries in TSC_DEADLINE MSR Write

### DIFF
--- a/src/platform/i386/lapic.c
+++ b/src/platform/i386/lapic.c
@@ -23,8 +23,6 @@
 
 #define IA32_MSR_TSC_DEADLINE  0x000006e0
 
-#define RETRY_ITERS            3
-
 extern int timer_process(struct pt_regs *regs);
 
 enum lapic_timer_type {
@@ -131,22 +129,7 @@ lapic_set_timer(int timer_type, cycles_t deadline)
 
 		lapic_write_reg(LAPIC_INIT_COUNT_REG, counter);
 	} else if (timer_type == LAPIC_TSC_DEADLINE) {
-		u32_t high, low;
-		int retries = RETRY_ITERS;
-
-retry:
 		writemsr(IA32_MSR_TSC_DEADLINE, (u32_t) ((deadline << 32) >> 32), (u32_t)(deadline >> 32));
-		readmsr(IA32_MSR_TSC_DEADLINE, &low, &high);
-		if (!low && !high) {
-			retries --;
-			if (retries > 0) {
-				goto retry;
-			}
-			else {
-				printk("Something wrong.. Cannot program TSC-DEADLINE\n");
-				assert(0);
-			}
-		}
 	} else {
 		printk("Mode (%d) not supported\n", timer_type);
 		assert(0);


### PR DESCRIPTION
### Summary of this PR

Intel's specification says writes to TSC_DEADLINE MSR are not serialized and therefore should not be used as serializing instruction. Serialization is only required between writes to TSC_DEADLINE MSR and memory mapped LVT REG, which isn't what I was doing. It introduces unnecessary race bugs and it also triggered the assert() in retry logic - when used in a full system of #rump2cos. 

To fix this, avoid Retries around TSC_DEADLINE MSR writes. (Also, retries weren't with relative times, absolute time retries could cause races especially if they are too close to current TSC). 

### Code Quality

As part of this pull request, I've considered the following:

Style:

- [x] Comments adhere to the Style Guide (SG)
- [x] Spacing adhere's to the SG 
- [x] Naming adhere's to the SG
- [x] All other aspects of the SG are adhered to, or exceptions are justified in this pull request

Code Craftsmanship:

- [x] I've made an attempt to remove all redundant code
- [x] I've considered ways in which my changes might impact existing code, and cleaned it up
- [x] I've formatted the code in an effort to make it easier to read (proper error handling, function use, etc...)
- [x] I've commented appropriately where code is tricky
- [x] I agree that there is no "throw-away" code, and that code in this PR is of high quality