### PR TITLE
Kernel changes related to Tcaps, Vkernel shared-mem and I/o cap feature addition

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@
 .fn_exports
 .exported_interfaces
 composite_new
+*.out
 tags
 src/kernel/include/shared/cpu_ghz.h
 src/Makefile.cosconfig

--- a/src/components/implementation/no_interface/vkernel/Makefile
+++ b/src/components/implementation/no_interface/vkernel/Makefile
@@ -1,4 +1,4 @@
-C_OBJS=mb_tests.o micro_booter.o vkernel.o
+C_OBJS=mb_tests.o micro_booter.o vkernel.o vk_api.o
 ASM_OBJS=cos_asm_scheduler.o inv.o
 COMPONENT=vkernel_boot.o
 INTERFACES=

--- a/src/components/implementation/no_interface/vkernel/micro_booter.c
+++ b/src/components/implementation/no_interface/vkernel/micro_booter.c
@@ -1,5 +1,6 @@
 #include "vk_types.h"
 #include "micro_booter.h"
+#include "vk_api.h"
 
 struct cos_compinfo booter_info;
 thdcap_t termthd = VM_CAPTBL_SELF_EXITTHD_BASE;	/* switch to this to shutdown */
@@ -46,7 +47,7 @@ vm_init(void *d)
 	vmid = (int)d;
 	cos_meminfo_init(&booter_info.mi, BOOT_MEM_KM_BASE, VM_UNTYPED_SIZE, BOOT_CAPTBL_SELF_UNTYPED_PT);
 	cos_compinfo_init(&booter_info, BOOT_CAPTBL_SELF_PT, BOOT_CAPTBL_SELF_CT, BOOT_CAPTBL_SELF_COMP,
-			  (vaddr_t)cos_get_heap_ptr(), VM_CAPTBL_FREE, &booter_info);
+			  (vaddr_t)cos_get_heap_ptr(), vmid == 0 ? DOM0_CAPTBL_FREE : VM_CAPTBL_FREE, &booter_info);
 
 	PRINTC("Micro Booter started.\n");
 	test_run_vk();
@@ -54,4 +55,22 @@ vm_init(void *d)
 
 	EXIT();
 	return;
+}
+
+void
+dom0_io_fn(void *id)
+{
+	arcvcap_t rcvcap = dom0_vio_rcvcap((unsigned int)id);
+	while (1) {
+		int pending = cos_rcv(rcvcap);
+	}
+}
+
+void
+vm_io_fn(void *id)
+{
+	arcvcap_t rcvcap = VM_CAPTBL_SELF_IORCV_BASE;
+	while (1) {
+		int pending = cos_rcv(rcvcap);
+	}
 }

--- a/src/components/implementation/no_interface/vkernel/vk_api.c
+++ b/src/components/implementation/no_interface/vkernel/vk_api.c
@@ -1,0 +1,43 @@
+#include "vk_api.h"
+
+void
+vk_shmem_alloc(struct vms_info *vminfo, struct vkernel_info *vkinfo, 
+	       unsigned long shm_ptr, unsigned long shm_sz)
+{
+	vaddr_t src_pg = (shm_sz * vminfo->id) + shm_ptr, dst_pg, addr;
+
+	assert(vminfo && vminfo->id == 0);
+	assert(shm_ptr == round_up_to_pgd_page(shm_ptr));
+
+	for (addr = shm_ptr ; addr < (shm_ptr + shm_sz) ; addr += PAGE_SIZE, src_pg += PAGE_SIZE) {
+		/* VM0: mapping in all available shared memory. */
+		src_pg = (vaddr_t)cos_page_bump_alloc(&vkinfo->shm_cinfo);
+		assert(src_pg && src_pg == addr);
+
+		dst_pg = cos_mem_alias(&vminfo->shm_cinfo, &vkinfo->shm_cinfo, src_pg);
+		assert(dst_pg && dst_pg == addr);
+	}	
+
+	return;
+}
+
+void
+vk_shmem_map(struct vms_info *vminfo, struct vkernel_info *vkinfo, 
+	     unsigned long shm_ptr, unsigned long shm_sz)
+{
+	vaddr_t src_pg = (shm_sz * vminfo->id) + shm_ptr, dst_pg, addr;
+
+	assert(vminfo && vminfo->id);
+	assert(shm_ptr == round_up_to_pgd_page(shm_ptr));
+
+	for (addr = shm_ptr ; addr < (shm_ptr + shm_sz) ; addr += PAGE_SIZE, src_pg += PAGE_SIZE) {
+		/* VMx: mapping in only a section of shared-memory to share with VM0 */
+		assert(src_pg);
+
+		dst_pg = cos_mem_alias(&vminfo->shm_cinfo, &vkinfo->shm_cinfo, src_pg);
+		assert(dst_pg && dst_pg == addr);
+	}	
+
+	return;
+}
+

--- a/src/components/implementation/no_interface/vkernel/vk_api.c
+++ b/src/components/implementation/no_interface/vkernel/vk_api.c
@@ -168,3 +168,7 @@ dom0_vio_rcvcap(unsigned int vmid)
 asndcap_t
 dom0_vio_asndcap(unsigned int vmid)
 { return DOM0_CAPTBL_SELF_IOASND_SET_BASE + (CAP64B_IDSZ * (vmid-1)); }
+
+vaddr_t
+dom0_vio_shm_base(unsigned int vmid)
+{ return VK_VM_SHM_BASE + (VM_SHM_SZ * vmid); }

--- a/src/components/implementation/no_interface/vkernel/vk_api.c
+++ b/src/components/implementation/no_interface/vkernel/vk_api.c
@@ -1,6 +1,68 @@
 #include "vk_api.h"
 
 void
+vk_initcaps_init(struct vms_info *vminfo, struct vkernel_info *vkinfo)
+{
+	struct cos_compinfo *vmcinfo = &vminfo->cinfo;
+	struct cos_compinfo *vkcinfo = &vkinfo->cinfo;
+	int ret;
+
+	vminfo->exitthd = cos_thd_alloc(vkcinfo, vkcinfo->comp_cap, vm_exit, (void *)vminfo->id);
+	assert(vminfo->exitthd);
+
+
+	vminfo->initthd = cos_thd_alloc(vkcinfo, vmcinfo->comp_cap, vm_init, (void *)vminfo->id);
+	assert(vminfo->initthd);
+	vminfo->inittid = (thdid_t)cos_introspect(vkcinfo, vminfo->initthd, THD_GET_TID);
+	printc("\tInit thread= cap:%x tid:%x\n", (unsigned int)vminfo->initthd, (unsigned int)vminfo->inittid);
+
+	printc("\tCreating and copying required initial capabilities\n");
+	/*
+	 * TODO: Multi-core support to create INITIAL Capabilities per core
+	 */
+	ret = cos_cap_cpy_at(vmcinfo, BOOT_CAPTBL_SELF_INITTHD_BASE, vkcinfo, vminfo->initthd);
+	assert(ret == 0);
+	ret = cos_cap_cpy_at(vmcinfo, BOOT_CAPTBL_SELF_INITHW_BASE, vkcinfo, BOOT_CAPTBL_SELF_INITHW_BASE);
+	assert(ret == 0);
+	ret = cos_cap_cpy_at(vmcinfo, VM_CAPTBL_SELF_EXITTHD_BASE, vkcinfo, vminfo->exitthd);
+	assert(ret == 0);
+
+	vminfo->inittcap = cos_tcap_alloc(vkcinfo, TCAP_PRIO_MAX);
+	assert(vminfo->inittcap);
+
+	vminfo->initrcv = cos_arcv_alloc(vkcinfo, vminfo->initthd, vminfo->inittcap, vkcinfo->comp_cap, BOOT_CAPTBL_SELF_INITRCV_BASE);
+	assert(vminfo->initrcv);
+
+	ret = cos_cap_cpy_at(vmcinfo, BOOT_CAPTBL_SELF_INITTCAP_BASE, vkcinfo, vminfo->inittcap);
+	assert(ret == 0);
+	ret = cos_cap_cpy_at(vmcinfo, BOOT_CAPTBL_SELF_INITRCV_BASE, vkcinfo, vminfo->initrcv);
+	assert(ret == 0);
+
+	/*
+	 * Create send end-point in VKernel to each VM's INITRCV end-point
+	 */
+	vkinfo->vminitasnd[vminfo->id] = cos_asnd_alloc(vkcinfo, vminfo->initrcv, vkcinfo->captbl_cap);
+	assert(vkinfo->vminitasnd[vminfo->id]);
+}
+
+void
+vk_virtmem_alloc(struct vms_info *vminfo, struct vkernel_info *vkinfo,
+		 unsigned long start_ptr, unsigned long range)
+{
+	vaddr_t addr;
+
+	for (addr = 0 ; addr < range ; addr += PAGE_SIZE) {
+		vaddr_t src_pg = (vaddr_t)cos_page_bump_alloc(&vkinfo->cinfo), dst_pg;
+		assert(src_pg);
+
+		memcpy((void *)src_pg, (void *)(start_ptr + addr), PAGE_SIZE);
+
+		dst_pg = cos_mem_alias(&vminfo->cinfo, &vkinfo->cinfo, src_pg);
+		assert(dst_pg);
+	}
+}
+
+void
 vk_shmem_alloc(struct vms_info *vminfo, struct vkernel_info *vkinfo, 
 	       unsigned long shm_ptr, unsigned long shm_sz)
 {

--- a/src/components/implementation/no_interface/vkernel/vk_api.h
+++ b/src/components/implementation/no_interface/vkernel/vk_api.h
@@ -1,0 +1,9 @@
+#ifndef VK_API_H
+#define VK_API_H
+
+#include "vk_types.h"
+
+void vk_shmem_alloc(struct vms_info *vminfo, struct vkernel_info *vkinfo, unsigned long shm_ptr, unsigned long shm_sz);
+void vk_shmem_map(struct vms_info *vminfo, struct vkernel_info *vkinfo, unsigned long shm_ptr, unsigned long shm_sz);
+
+#endif /* VK_API_H */

--- a/src/components/implementation/no_interface/vkernel/vk_api.h
+++ b/src/components/implementation/no_interface/vkernel/vk_api.h
@@ -3,6 +3,14 @@
 
 #include "vk_types.h"
 
+/* extern functions */
+extern void vm_exit(void *);
+extern void vm_init(void *);
+
+/* api */
+void vk_initcaps_init(struct vms_info *vminfo, struct vkernel_info *vkinfo);
+
+void vk_virtmem_alloc(struct vms_info *vminfo, struct vkernel_info *vkinfo, unsigned long start_ptr, unsigned long range);
 void vk_shmem_alloc(struct vms_info *vminfo, struct vkernel_info *vkinfo, unsigned long shm_ptr, unsigned long shm_sz);
 void vk_shmem_map(struct vms_info *vminfo, struct vkernel_info *vkinfo, unsigned long shm_ptr, unsigned long shm_sz);
 

--- a/src/components/implementation/no_interface/vkernel/vk_api.h
+++ b/src/components/implementation/no_interface/vkernel/vk_api.h
@@ -22,4 +22,6 @@ tcap_t dom0_vio_tcap(unsigned int vmid);
 arcvcap_t dom0_vio_rcvcap(unsigned int vmid);
 asndcap_t dom0_vio_asndcap(unsigned int vmid);
 
+vaddr_t dom0_vio_shm_base(unsigned int vmid);
+
 #endif /* VK_API_H */

--- a/src/components/implementation/no_interface/vkernel/vk_api.h
+++ b/src/components/implementation/no_interface/vkernel/vk_api.h
@@ -6,12 +6,20 @@
 /* extern functions */
 extern void vm_exit(void *);
 extern void vm_init(void *);
+extern void dom0_io_fn(void *);
+extern void vm_io_fn(void *);
 
 /* api */
 void vk_initcaps_init(struct vms_info *vminfo, struct vkernel_info *vkinfo);
+void vk_iocaps_init(struct vms_info *vminfo, struct vms_info *dom0info, struct vkernel_info *vkinfo);
 
 void vk_virtmem_alloc(struct vms_info *vminfo, struct vkernel_info *vkinfo, unsigned long start_ptr, unsigned long range);
 void vk_shmem_alloc(struct vms_info *vminfo, struct vkernel_info *vkinfo, unsigned long shm_ptr, unsigned long shm_sz);
 void vk_shmem_map(struct vms_info *vminfo, struct vkernel_info *vkinfo, unsigned long shm_ptr, unsigned long shm_sz);
+
+thdcap_t dom0_vio_thdcap(unsigned int vmid);
+tcap_t dom0_vio_tcap(unsigned int vmid);
+arcvcap_t dom0_vio_rcvcap(unsigned int vmid);
+asndcap_t dom0_vio_asndcap(unsigned int vmid);
 
 #endif /* VK_API_H */

--- a/src/components/implementation/no_interface/vkernel/vk_types.h
+++ b/src/components/implementation/no_interface/vkernel/vk_types.h
@@ -16,13 +16,41 @@
 
 enum vm_captbl_layout {
 	VM_CAPTBL_SELF_EXITTHD_BASE    = BOOT_CAPTBL_FREE,
-	VM_CAPTBL_LAST_CAP             = VM_CAPTBL_SELF_EXITTHD_BASE + NUM_CPU_COS*CAP16B_IDSZ,
-	VM_CAPTBL_FREE                 = round_up_to_pow2(VM_CAPTBL_LAST_CAP, CAPMAX_ENTRY_SZ),
+
+	/* VM1~ I/O Capabilities layout */
+        VM_CAPTBL_SELF_IOTHD_BASE      = round_up_to_pow2(VM_CAPTBL_SELF_EXITTHD_BASE + NUM_CPU_COS*CAP16B_IDSZ, CAPMAX_ENTRY_SZ),
+        VM_CAPTBL_SELF_IORCV_BASE      = round_up_to_pow2(VM_CAPTBL_SELF_IOTHD_BASE + CAP16B_IDSZ, CAPMAX_ENTRY_SZ),
+        VM_CAPTBL_SELF_IOASND_BASE     = round_up_to_pow2(VM_CAPTBL_SELF_IORCV_BASE + CAP64B_IDSZ, CAPMAX_ENTRY_SZ),
+        VM_CAPTBL_SELF_LAST_CAP        = VM_CAPTBL_SELF_IOASND_BASE + CAP64B_IDSZ,
+	VM_CAPTBL_FREE                 = round_up_to_pow2(VM_CAPTBL_SELF_LAST_CAP, CAPMAX_ENTRY_SZ),
+};
+
+enum dom0_captbl_layout {
+	/* DOM0 I/O Capabilities layout */
+        DOM0_CAPTBL_SELF_IOTHD_SET_BASE      = VM_CAPTBL_SELF_IOTHD_BASE,
+        DOM0_CAPTBL_SELF_IOTCAP_SET_BASE     = round_up_to_pow2(DOM0_CAPTBL_SELF_IOTHD_SET_BASE + CAP16B_IDSZ*((VM_COUNT>1 ? VM_COUNT-1 : 1)), CAPMAX_ENTRY_SZ),
+        DOM0_CAPTBL_SELF_IORCV_SET_BASE      = round_up_to_pow2(DOM0_CAPTBL_SELF_IOTCAP_SET_BASE + CAP16B_IDSZ*((VM_COUNT>1 ? VM_COUNT-1 : 1)), CAPMAX_ENTRY_SZ),
+        DOM0_CAPTBL_SELF_IOASND_SET_BASE     = round_up_to_pow2(DOM0_CAPTBL_SELF_IORCV_SET_BASE + CAP64B_IDSZ*((VM_COUNT>1 ? VM_COUNT-1 : 1)), CAPMAX_ENTRY_SZ),
+        DOM0_CAPTBL_SELF_LAST_CAP            = DOM0_CAPTBL_SELF_IOASND_SET_BASE + CAP64B_IDSZ*((VM_COUNT>1 ? VM_COUNT-1 : 1)),
+	DOM0_CAPTBL_FREE                     = round_up_to_pow2(DOM0_CAPTBL_SELF_LAST_CAP, CAPMAX_ENTRY_SZ),
 };
 
 enum vm_state {
 	VM_RUNNING = 0,	
 	VM_EXITED  = 1,
+};
+
+struct vm_io_info {
+	thdcap_t iothd;
+	arcvcap_t iorcv;
+	asndcap_t ioasnd;
+};
+
+struct dom0_io_info {
+	thdcap_t iothds[VM_COUNT-1];
+	tcap_t iotcaps[VM_COUNT-1];
+	arcvcap_t iorcvs[VM_COUNT-1];
+	asndcap_t ioasnds[VM_COUNT-1];
 };
 
 struct vms_info {
@@ -34,6 +62,11 @@ struct vms_info {
 	thdid_t inittid;
 	tcap_t inittcap;
 	arcvcap_t initrcv;
+
+	union { /* for clarity */
+		struct vm_io_info *vmio;
+		struct dom0_io_info *dom0io;
+	};
 };
 
 struct vkernel_info {

--- a/src/components/implementation/no_interface/vkernel/vk_types.h
+++ b/src/components/implementation/no_interface/vkernel/vk_types.h
@@ -2,6 +2,17 @@
 #define VK_TYPES_H
 
 #include <cos_types.h>
+#include <cos_kernel_api.h>
+
+#define VM_COUNT        2	/* virtual machine count */
+#define VM_UNTYPED_SIZE (1<<26) /* untyped memory per vm = 64MB */
+
+#define VK_VM_SHM_BASE  0x80000000      /* shared memory region */
+#define VM_SHM_SZ       (1<<20)	        /* Shared memory mapping for each vm = 4MB */
+#define VM_SHM_ALL_SZ   ((VM_COUNT>0)?(VM_COUNT*VM_SHM_SZ):VM_SHM_SZ)
+
+#define VM_BUDGET_FIXED 400000
+#define VM_PRIO_FIXED   TCAP_PRIO_MAX
 
 enum vm_captbl_layout {
 	VM_CAPTBL_SELF_EXITTHD_BASE    = BOOT_CAPTBL_FREE,
@@ -9,10 +20,21 @@ enum vm_captbl_layout {
 	VM_CAPTBL_FREE                 = round_up_to_pow2(VM_CAPTBL_LAST_CAP, CAPMAX_ENTRY_SZ),
 };
 
-#define VM_COUNT        2	/* virtual machine count */
-#define VM_UNTYPED_SIZE (1<<26) /* untyped memory per vm = 64MB */
+struct vms_info {
+	unsigned int id;
+	struct cos_compinfo cinfo, shm_cinfo;
 
-#define VM_BUDGET_FIXED 400000
-#define VM_PRIO_FIXED   TCAP_PRIO_MAX
+	thdcap_t initthd, exitthd;
+	thdid_t inittid;
+	tcap_t inittcap;
+	arcvcap_t initrcv;
+};
+
+struct vkernel_info {
+	struct cos_compinfo cinfo, shm_cinfo;
+
+	thdcap_t termthd;
+	asndcap_t vminitasnd[VM_COUNT];
+};
 
 #endif /* VK_TYPES_H */

--- a/src/components/implementation/no_interface/vkernel/vk_types.h
+++ b/src/components/implementation/no_interface/vkernel/vk_types.h
@@ -20,10 +20,16 @@ enum vm_captbl_layout {
 	VM_CAPTBL_FREE                 = round_up_to_pow2(VM_CAPTBL_LAST_CAP, CAPMAX_ENTRY_SZ),
 };
 
+enum vm_state {
+	VM_RUNNING = 0,	
+	VM_EXITED  = 1,
+};
+
 struct vms_info {
 	unsigned int id;
 	struct cos_compinfo cinfo, shm_cinfo;
 
+	unsigned int state;
 	thdcap_t initthd, exitthd;
 	thdid_t inittid;
 	tcap_t inittcap;

--- a/src/components/implementation/no_interface/vkernel/vkernel.c
+++ b/src/components/implementation/no_interface/vkernel/vkernel.c
@@ -29,7 +29,7 @@ vm_exit(void *d)
 {
 	printc("%d: EXIT\n", (int)d);
 	ready_vms --;
-	vmx_info[(int)d].initthd = 0;	
+	vmx_info[(int)d].state = VM_EXITED;	
 
 	while (1) cos_thd_switch(BOOT_CAPTBL_SELF_INITTHD_BASE);
 }
@@ -46,7 +46,7 @@ scheduler(void)
 	while (ready_vms) {
 		index = i++ % VM_COUNT;
 		
-		if (vmx_info[index].initthd) {
+		if (vmx_info[index].state == VM_RUNNING) {
 			assert(vk_info.vminitasnd[index]);
 
 			if (cos_tcap_delegate(vk_info.vminitasnd[index], BOOT_CAPTBL_SELF_INITTCAP_BASE,
@@ -188,6 +188,7 @@ cos_init(void)
 		}
 
 		printc("vkernel: VM%d Init END\n", id);
+		vm_info->state = VM_RUNNING;
 	}
 
 	printc("Starting Scheduler\n");

--- a/src/components/implementation/tests/micro_booter/mb_tests.c
+++ b/src/components/implementation/tests/micro_booter/mb_tests.c
@@ -354,7 +354,7 @@ test_timer(void)
 
 		rdtscll(now);
 		timer = tcap_cyc2time(now + 1000 * cyc_per_usec);
-		cos_switch(tc, BOOT_CAPTBL_SELF_INITTCAP_BASE, 0, timer, BOOT_CAPTBL_SELF_INITRCV_BASE);
+		cos_switch(tc, BOOT_CAPTBL_SELF_INITTCAP_BASE, 0, timer, BOOT_CAPTBL_SELF_INITRCV_BASE, cos_sched_sync());
 		p     = c;
 		rdtscll(c);
 		if (i > 0) t += c-p;
@@ -429,7 +429,7 @@ test_budgets_single(void)
 		if (cos_tcap_transfer(bt.c.rc, BOOT_CAPTBL_SELF_INITTCAP_BASE, i * 100000, TCAP_PRIO_MAX + 2)) assert(0);
 
 		rdtscll(s);
-		if (cos_switch(bt.c.tc, bt.c.tcc, TCAP_PRIO_MAX + 2, TCAP_TIME_NIL, BOOT_CAPTBL_SELF_INITRCV_BASE)) assert(0);
+		if (cos_switch(bt.c.tc, bt.c.tcc, TCAP_PRIO_MAX + 2, TCAP_TIME_NIL, BOOT_CAPTBL_SELF_INITRCV_BASE, cos_sched_sync())) assert(0);
 		rdtscll(e);
 		PRINTC("%lld,\t", e-s);
 
@@ -466,7 +466,7 @@ test_budgets_multi(void)
 		if (cos_tcap_transfer(mbt.g.rc, mbt.c.tcc, res/4, TCAP_PRIO_MAX + 2)) assert(0);
 
 		rdtscll(s);
-		if (cos_switch(mbt.g.tc, mbt.g.tcc, TCAP_PRIO_MAX + 2, TCAP_TIME_NIL, BOOT_CAPTBL_SELF_INITRCV_BASE)) assert(0);
+		if (cos_switch(mbt.g.tc, mbt.g.tcc, TCAP_PRIO_MAX + 2, TCAP_TIME_NIL, BOOT_CAPTBL_SELF_INITRCV_BASE, cos_sched_sync())) assert(0);
 		rdtscll(e);
 		PRINTC("g:%llu c:%llu p:%llu => %llu,\t", mbt.g.cyc - s, mbt.c.cyc - s, mbt.p.cyc - s, e - s);
 

--- a/src/components/implementation/tests/micro_booter/mb_tests.c
+++ b/src/components/implementation/tests/micro_booter/mb_tests.c
@@ -120,11 +120,11 @@ async_thd_parent_perf(void *thdcap)
 	long long start_asnd_cycles = 0, end_arcv_cycles = 0;
 	int i;
 
-	cos_asnd(sc);
+	cos_asnd(sc, 1);
 
 	rdtscll(start_asnd_cycles);
 	for (i = 0 ; i < ITER ; i++) {
-		cos_asnd(sc);
+		cos_asnd(sc, 1);
 	}
 	rdtscll(end_arcv_cycles);
 	total_asnd_cycles = (end_arcv_cycles - start_asnd_cycles) / 2;
@@ -170,11 +170,11 @@ async_thd_parent(void *thdcap)
 	cycles_t  cycles;
 
 	PRINTC("--> sending\n");
-	ret     = cos_asnd(sc);
+	ret     = cos_asnd(sc, 0);
 	if (ret) PRINTC("asnd returned %d.\n", ret);
 	PRINTC("--> Back in the asnder.\n");
 	PRINTC("--> sending\n");
-	ret     = cos_asnd(sc);
+	ret     = cos_asnd(sc, 1);
 	if (ret) PRINTC("--> asnd returned %d.\n", ret);
 	PRINTC("--> Back in the asnder.\n");
 	PRINTC("--> receiving to get notifications\n");
@@ -291,7 +291,7 @@ tcap_parent(void *d)
 	asndcap_t __tc_sc = (asndcap_t)d;
 
 	for (i = 0 ; i < ITER ; i++) {
-		cos_asnd(__tc_sc);
+		cos_asnd(__tc_sc, 0);
 	}
 }
 

--- a/src/components/implementation/tests/micro_booter/mb_tests.c
+++ b/src/components/implementation/tests/micro_booter/mb_tests.c
@@ -429,7 +429,7 @@ test_budgets_single(void)
 		if (cos_tcap_transfer(bt.c.rc, BOOT_CAPTBL_SELF_INITTCAP_BASE, i * 100000, TCAP_PRIO_MAX + 2)) assert(0);
 
 		rdtscll(s);
-		if (cos_switch(bt.c.tc, bt.c.tcc, TCAP_PRIO_MAX + 2, TCAP_RES_INF, BOOT_CAPTBL_SELF_INITRCV_BASE)) assert(0);
+		if (cos_switch(bt.c.tc, bt.c.tcc, TCAP_PRIO_MAX + 2, TCAP_TIME_NIL, BOOT_CAPTBL_SELF_INITRCV_BASE)) assert(0);
 		rdtscll(e);
 		PRINTC("%lld,\t", e-s);
 
@@ -466,7 +466,7 @@ test_budgets_multi(void)
 		if (cos_tcap_transfer(mbt.g.rc, mbt.c.tcc, res/4, TCAP_PRIO_MAX + 2)) assert(0);
 
 		rdtscll(s);
-		if (cos_switch(mbt.g.tc, mbt.g.tcc, TCAP_PRIO_MAX + 2, TCAP_RES_INF, BOOT_CAPTBL_SELF_INITRCV_BASE)) assert(0);
+		if (cos_switch(mbt.g.tc, mbt.g.tcc, TCAP_PRIO_MAX + 2, TCAP_TIME_NIL, BOOT_CAPTBL_SELF_INITRCV_BASE)) assert(0);
 		rdtscll(e);
 		PRINTC("g:%llu c:%llu p:%llu => %llu,\t", mbt.g.cyc - s, mbt.c.cyc - s, mbt.p.cyc - s, e - s);
 
@@ -598,7 +598,7 @@ void
 test_run_mb(void)
 {
 	test_timer();
-//	test_budgets();
+	test_budgets();
 
 	test_thds();
 	test_thds_perf();

--- a/src/components/include/cos_kernel_api.h
+++ b/src/components/include/cos_kernel_api.h
@@ -76,7 +76,8 @@ int cos_cap_cpy_at(struct cos_compinfo *dstci, capid_t dstcap, struct cos_compin
 
 int cos_thd_switch(thdcap_t c);
 #define CAP_NULL 0
-int cos_switch(thdcap_t c, tcap_t t, tcap_prio_t p, tcap_time_t r, arcvcap_t rcv);
+sched_tok_t cos_sched_sync(void);
+int cos_switch(thdcap_t c, tcap_t t, tcap_prio_t p, tcap_time_t r, arcvcap_t rcv, sched_tok_t stok);
 int cos_thd_mod(struct cos_compinfo *ci, thdcap_t c, void *tls_addr); /* set tls addr of thd in captbl */
 
 int cos_asnd(asndcap_t snd, int yield);

--- a/src/components/include/cos_kernel_api.h
+++ b/src/components/include/cos_kernel_api.h
@@ -79,7 +79,7 @@ int cos_thd_switch(thdcap_t c);
 int cos_switch(thdcap_t c, tcap_t t, tcap_prio_t p, tcap_time_t r, arcvcap_t rcv);
 int cos_thd_mod(struct cos_compinfo *ci, thdcap_t c, void *tls_addr); /* set tls addr of thd in captbl */
 
-int cos_asnd(asndcap_t snd);
+int cos_asnd(asndcap_t snd, int yield);
 /* returns non-zero if there are still pending events (i.e. there have been pending snds) */
 int cos_rcv(arcvcap_t rcv);
 /* returns the same value as cos_rcv, but also information about scheduling events */

--- a/src/components/lib/cos_kernel_api.c
+++ b/src/components/lib/cos_kernel_api.c
@@ -654,8 +654,8 @@ cos_switch(thdcap_t c, tcap_t tc, tcap_prio_t prio, tcap_time_t timeout, arcvcap
 { return call_cap_op(c, 0, tc << 16 | rcv, (prio << 32) >> 32, prio >> 32, timeout); }
 
 int
-cos_asnd(asndcap_t snd)
-{ return call_cap_op(snd, 0, 0, 0, 0, 0); }
+cos_asnd(asndcap_t snd, int yield)
+{ return call_cap_op(snd, 0, yield, 0, 0, 0); }
 
 int
 cos_sched_rcv(arcvcap_t rcv, thdid_t *thdid, int *blocked, cycles_t *cycles)

--- a/src/components/lib/cos_kernel_api.c
+++ b/src/components/lib/cos_kernel_api.c
@@ -649,9 +649,13 @@ int
 cos_thd_switch(thdcap_t c)
 { return call_cap_op(c, 0, 0, 0, 0, 0); }
 
+sched_tok_t
+cos_sched_sync(void)
+{ static sched_tok_t stok; return __sync_add_and_fetch(&stok, 1); }
+
 int
-cos_switch(thdcap_t c, tcap_t tc, tcap_prio_t prio, tcap_time_t timeout, arcvcap_t rcv)
-{ return call_cap_op(c, 0, tc << 16 | rcv, (prio << 32) >> 32, prio >> 32, timeout); }
+cos_switch(thdcap_t c, tcap_t tc, tcap_prio_t prio, tcap_time_t timeout, arcvcap_t rcv, sched_tok_t stok)
+{ return call_cap_op(c, (stok >> 16), tc << 16 | rcv, (prio << 32) >> 32, ((prio << 16) >> 32) | ((stok << 16) >> 16), timeout); }
 
 int
 cos_asnd(asndcap_t snd, int yield)

--- a/src/kernel/capinv.c
+++ b/src/kernel/capinv.c
@@ -544,7 +544,7 @@ cap_thd_op(struct cap_thd *thd_cap, struct thread *thd, struct pt_regs *regs,
 		if (!CAP_TYPECHK_CORE(tcap_cap, CAP_TCAP)) return -EINVAL;
 		tcap = tcap_cap->tcap;
 
-		/* TODO: update prio and timeout */
+		tcap_setprio(tcap, prio);
 	}
 
 	return cap_switch(regs, thd, next, tcap, timeout, ci, cos_info);

--- a/src/kernel/capinv.c
+++ b/src/kernel/capinv.c
@@ -596,6 +596,7 @@ cap_thd_op(struct cap_thd *thd_cap, struct thread *thd, struct pt_regs *regs,
 	tcap_prio_t prio    = (tcap_prio_t)prio_higher << 32 | (tcap_prio_t)prio_lower;
 	tcap_time_t timeout = (tcap_time_t)__userregs_get4(regs);
 	struct tcap *tcap   = tcap_current(cos_info);
+	int ret;
 
 	if (thd_cap->cpuid != get_cpuid() || thd_cap->cpuid != next->cpuid) return -EINVAL;
 
@@ -621,11 +622,12 @@ cap_thd_op(struct cap_thd *thd_cap, struct thread *thd, struct pt_regs *regs,
 		tcap_cap = (struct cap_tcap *)captbl_lkup(ci->captbl, tc);
 		if (!CAP_TYPECHK_CORE(tcap_cap, CAP_TCAP)) return -EINVAL;
 		tcap = tcap_cap->tcap;
-
-		tcap_setprio(tcap, prio);
 	}
 
-	return cap_switch(regs, thd, next, tcap, timeout, ci, cos_info);
+	ret = cap_switch(regs, thd, next, tcap, timeout, ci, cos_info);
+	if (tc && tcap_current(cos_info) == tcap) tcap_setprio(tcap, prio);
+
+	return ret;
 }
 
 static inline struct cap_arcv *

--- a/src/kernel/capinv.c
+++ b/src/kernel/capinv.c
@@ -648,6 +648,7 @@ cap_asnd_op(struct cap_asnd *asnd, struct thread *thd, struct pt_regs *regs,
 	    struct comp_info *ci, struct cos_cpu_local_info *cos_info)
 {
 	int curr_cpu = get_cpuid();
+	int yield    = __userregs_get1(regs);
 	struct cap_arcv *arcv;
 	struct thread *rcv_thd, *next;
 	struct tcap *rcv_tcap, *tcap, *tcap_next;
@@ -663,7 +664,7 @@ cap_asnd_op(struct cap_asnd *asnd, struct thread *thd, struct pt_regs *regs,
 	rcv_tcap = rcv_thd->rcvcap.rcvcap_tcap;
 	assert(rcv_tcap && tcap);
 
-	next = asnd_process(rcv_thd, thd, rcv_tcap, tcap, &tcap_next, 0);
+	next = asnd_process(rcv_thd, thd, rcv_tcap, tcap, &tcap_next, yield);
 
 	return cap_switch(regs, thd, next, tcap_next, TCAP_TIME_NIL, ci, cos_info);
 }

--- a/src/kernel/include/chal.h
+++ b/src/kernel/include/chal.h
@@ -94,6 +94,7 @@ void chal_send_ipi(int cpuid);
 /* static const struct cos_trans_fns *trans_fns = NULL; */
 void chal_idle(void);
 void chal_timer_set(cycles_t cycles);
+void chal_timer_disable(void);
 
 void chal_init(void);
 

--- a/src/kernel/include/shared/cos_types.h
+++ b/src/kernel/include/shared/cos_types.h
@@ -184,6 +184,7 @@ typedef unsigned long capid_t;
 #define TCAP_RES_PACK(r)   (round_up_to_pow2((r), 1 << TCAP_RES_GRAN_ORD))
 #define TCAP_RES_EXPAND(r) ((r) << TCAP_RES_GRAN_ORD)
 #define TCAP_RES_INF  (~0UL)
+#define TCAP_RES_MAX  (TCAP_RES_INF - 1)
 #define TCAP_RES_IS_INF(r) (r == TCAP_RES_INF)
 typedef capid_t tcap_t;
 

--- a/src/kernel/include/shared/cos_types.h
+++ b/src/kernel/include/shared/cos_types.h
@@ -36,6 +36,7 @@ typedef unsigned long tcap_res_t;
 typedef unsigned long tcap_time_t;
 typedef u64_t tcap_prio_t;
 typedef u64_t tcap_uid_t;
+typedef u32_t sched_tok_t;
 #define PRINT_CAP_TEMP (1 << 14)
 
 /*
@@ -179,7 +180,7 @@ typedef enum {
 
 typedef unsigned long capid_t;
 #define TCAP_PRIO_MAX (1ULL)
-#define TCAP_PRIO_MIN (~0ULL)
+#define TCAP_PRIO_MIN ((~0ULL) >> 16) /* 48bit value */
 #define TCAP_RES_GRAN_ORD  16
 #define TCAP_RES_PACK(r)   (round_up_to_pow2((r), 1 << TCAP_RES_GRAN_ORD))
 #define TCAP_RES_EXPAND(r) ((r) << TCAP_RES_GRAN_ORD)

--- a/src/kernel/include/shared/cos_types.h
+++ b/src/kernel/include/shared/cos_types.h
@@ -188,6 +188,8 @@ typedef unsigned long capid_t;
 #define TCAP_RES_IS_INF(r) (r == TCAP_RES_INF)
 typedef capid_t tcap_t;
 
+#define ARCV_NOTIF_DEPTH 8
+
 #define QUIESCENCE_CHECK(curr, past, quiescence_period)  (((curr) - (past)) > (quiescence_period))
 
 /*

--- a/src/kernel/include/tcap.h
+++ b/src/kernel/include/tcap.h
@@ -208,16 +208,12 @@ tcap_timer_update(struct cos_cpu_local_info *cos_info, struct tcap *next, tcap_t
 
 	/* timeout based on the tcap budget... */
 	timer       = now + left;
-	/* overflow?  especially relevant if left = TCAP_RES_INF */
-	if (unlikely(timer <= now)) return;
 	timeout_cyc = tcap_time2cyc(timeout, now);
 	/* ...or explicit timeout within the bounds of the budget */
 	if (timeout != TCAP_TIME_NIL && timeout_cyc < timer) {
 		if (tcap_time_lessthan(timeout, tcap_cyc2time(now))) timer = now;
 		else                                                 timer = timeout_cyc;
 	}
-	/* avoid the large costs of setting the timer hardware if possible */
-	if (cycles_same(cos_info->timeout_next, timer)) return;
 
 	chal_timer_set(timer);
 	cos_info->timeout_next = timer;

--- a/src/kernel/include/tcap.h
+++ b/src/kernel/include/tcap.h
@@ -205,11 +205,7 @@ tcap_timer_update(struct cos_cpu_local_info *cos_info, struct tcap *next, tcap_t
 	/* next == INF? no timer required. */
 	left        = tcap_left(next);
 	if (timeout == TCAP_TIME_NIL && TCAP_RES_IS_INF(left)) {
-		if (cos_info->timeout_next) {
-			chal_timer_disable();
-			cos_info->timeout_next = 0;
-		}
-
+		chal_timer_disable();
 		return;
 	} 
 
@@ -223,7 +219,6 @@ tcap_timer_update(struct cos_cpu_local_info *cos_info, struct tcap *next, tcap_t
 	}
 
 	chal_timer_set(timer);
-	cos_info->timeout_next = timer;
 }
 
 /*

--- a/src/kernel/include/tcap.h
+++ b/src/kernel/include/tcap.h
@@ -204,7 +204,14 @@ tcap_timer_update(struct cos_cpu_local_info *cos_info, struct tcap *next, tcap_t
 
 	/* next == INF? no timer required. */
 	left        = tcap_left(next);
-	if (timeout == TCAP_TIME_NIL && TCAP_RES_IS_INF(left)) return;
+	if (timeout == TCAP_TIME_NIL && TCAP_RES_IS_INF(left)) {
+		if (cos_info->timeout_next) {
+			chal_timer_disable();
+			cos_info->timeout_next = 0;
+		}
+
+		return;
+	} 
 
 	/* timeout based on the tcap budget... */
 	timer       = now + left;

--- a/src/kernel/include/tcap.h
+++ b/src/kernel/include/tcap.h
@@ -169,7 +169,7 @@ tcap_current_set(struct cos_cpu_local_info *cos_info, struct tcap *t)
 	struct tcap *curr = tcap_current(cos_info);
 
 	/* remove transient prio on current tcap before switching to a new tcap */
-	if(curr != t && curr->perm_prio != tcap_sched_info(curr)->prio) tcap_setprio(curr, curr->perm_prio);
+	if(curr->perm_prio != tcap_sched_info(curr)->prio) tcap_setprio(curr, curr->perm_prio);
 	cos_info->curr_tcap = t;
 }
 

--- a/src/kernel/include/thd.h
+++ b/src/kernel/include/thd.h
@@ -41,6 +41,7 @@ struct rcvcap_info {
 typedef enum {
 	THD_STATE_PREEMPTED   = 1,
 	THD_STATE_RCVING      = 1<<1, /* report to parent rcvcap that we're receiving */
+	THD_STATE_SUSPENDED   = 1<<2,
 } thd_state_t;
 
 /**

--- a/src/kernel/include/thd.h
+++ b/src/kernel/include/thd.h
@@ -34,6 +34,7 @@ struct invstk_entry {
 struct rcvcap_info {
 	/* how many other arcv end-points send notifications to this one? */
 	int isbound, pending, refcnt;
+	sched_tok_t sched_count;
 	struct tcap   *rcvcap_tcap;      /* This rcvcap's tcap */
 	struct thread *rcvcap_thd_notif; /* The parent rcvcap thread for notifications */
 };
@@ -157,6 +158,7 @@ thd_rcvcap_init(struct thread *t)
 	struct rcvcap_info *rc = &t->rcvcap;
 
 	rc->isbound = rc->pending = rc->refcnt = 0;
+	rc->sched_count = 0;
 	rc->rcvcap_thd_notif = NULL;
 }
 
@@ -181,6 +183,14 @@ thd_track_exec(struct thread *t) { return !list_empty(&t->event_list); }
 static int
 thd_rcvcap_pending(struct thread *t)
 { return t->rcvcap.pending || list_first(&t->event_head) != NULL; }
+
+static sched_tok_t
+thd_rcvcap_get_counter(struct thread *t)
+{ return t->rcvcap.sched_count; }
+
+static void
+thd_rcvcap_set_counter(struct thread *t, sched_tok_t cntr)
+{ t->rcvcap.sched_count = cntr; }
 
 static void
 thd_rcvcap_pending_inc(struct thread *arcvt)

--- a/src/kernel/tcap.c
+++ b/src/kernel/tcap.c
@@ -73,8 +73,13 @@ __tcap_budget_xfer(struct tcap *d, struct tcap *s, tcap_res_t cycles)
 		bd->cycles = TCAP_RES_INF;
 		goto done;
 	}
-	if (unlikely(cycles > bs->cycles)) return -1;
-	if (!TCAP_RES_IS_INF(bd->cycles)) bd->cycles += cycles;
+	if (unlikely(cycles > bs->cycles)) cycles = bs->cycles;
+	if (!TCAP_RES_IS_INF(bd->cycles)) {
+		tcap_res_t bd_cycs = bd->cycles + cycles;
+
+		if (bd_cycs < bd->cycles || TCAP_RES_IS_INF(bd_cycs)) bd->cycles = TCAP_RES_MAX;
+		else                                                  bd->cycles = bd_cycs;
+	}
 	if (!TCAP_RES_IS_INF(bs->cycles)) bs->cycles -= cycles;
 done:
 	if (!tcap_is_active(d)) tcap_active_add_before(s, d);

--- a/src/platform/i386/boot_comp.c
+++ b/src/platform/i386/boot_comp.c
@@ -103,11 +103,12 @@ kern_boot_thd(struct captbl *ct, void *thd_mem, void *tcap_mem)
 	ret = tcap_activate(ct, BOOT_CAPTBL_SELF_CT, BOOT_CAPTBL_SELF_INITTCAP_BASE, tcap_mem, TCAP_PRIO_MAX);
 	assert(!ret);
 	tc->budget.cycles = TCAP_RES_INF; /* Chronos's got all the time in the world */
+	tc->perm_prio     = 0;
 	tcap_setprio(tc, 0);              /* Chronos gets preempted by no one! */
 	list_enqueue(&cos_info->tcaps, &tc->active_list); /* Chronos on the TCap active list */
-	cos_info->tcap_uid = 1;
-	cos_info->cycles   = tsc();
-	tcap_current_set(cos_info, tc);
+	cos_info->tcap_uid  = 1;
+	cos_info->cycles    = tsc();
+	cos_info->curr_tcap = tc;
 
 	thd_current_update(t, t, cos_info);
 

--- a/src/platform/i386/chal/cpuid.h
+++ b/src/platform/i386/chal/cpuid.h
@@ -39,7 +39,7 @@ struct cos_cpu_local_info {
 	struct list tcaps;
 	tcap_uid_t  tcap_uid;
 	tcap_prio_t tcap_prio;
-	cycles_t    timeout_next, cycles;
+	cycles_t    cycles;
 	/*
 	 * cache the stk_top index to save a cacheline access on
 	 * inv/ret. Could use a struct here if need to cache multiple

--- a/src/platform/i386/chal_asm_inc.h
+++ b/src/platform/i386/chal_asm_inc.h
@@ -10,5 +10,5 @@
 #define SEL_UGSEG       (0x30|SEL_RPL_USR)    /* User TLS selector. */
 #define SEL_CNT         7       /* Number of segments. */
 
-#define STK_INFO_SZ     72	/* sizeof(struct cos_cpu_local_info) */
+#define STK_INFO_SZ     64	/* sizeof(struct cos_cpu_local_info) */
 #define STK_INFO_OFF    (STK_INFO_SZ + 4)	/* sizeof(struct cos_cpu_local_info) + sizeof(long) */

--- a/src/platform/i386/lapic.c
+++ b/src/platform/i386/lapic.c
@@ -17,7 +17,7 @@
 #define LAPIC_PERIODIC_MODE    (0x01 << 17)
 #define LAPIC_ONESHOT_MODE     (0x00 << 17)
 #define LAPIC_TSCDEADLINE_MODE (0x02 << 17)
-#define LAPIC_INT_MASK         (1<<15)
+#define LAPIC_INT_MASK         (1<<16)
 
 #define LAPIC_TIMER_CALIB_VAL  0xffffffff
 

--- a/src/platform/i386/lapic.c
+++ b/src/platform/i386/lapic.c
@@ -118,6 +118,19 @@ lapic_find_localaddr(void *l)
 }
 
 void
+lapic_disable_timer(int timer_type)
+{
+	if (timer_type == LAPIC_ONESHOT) {
+		lapic_write_reg(LAPIC_INIT_COUNT_REG, 0);
+	} else if (timer_type == LAPIC_TSC_DEADLINE) {
+		writemsr(IA32_MSR_TSC_DEADLINE, 0, 0);
+	} else {
+		printk("Mode (%d) not supported\n", timer_type);
+		assert(0);
+	}
+}
+
+void
 lapic_set_timer(int timer_type, cycles_t deadline)
 {
 	u64_t now;
@@ -182,6 +195,10 @@ lapic_timer_calibration(u32_t ratio)
 void
 chal_timer_set(cycles_t cycles)
 { lapic_set_timer(lapic_timer_mode, cycles); }
+
+void
+chal_timer_disable(void)
+{ lapic_disable_timer(lapic_timer_mode); }
 
 void
 lapic_timer_init(void)


### PR DESCRIPTION
### Summary of this PR

Kernel changes:
- APIC timer: 1. If already disabled, don't redo it. 2. Set a minimum timer if deadline has passed.
- TCap budget checks in Tcap API
- Thread switch with Tcap transient priorities
- Hierarchical scheduling notifications

Vkernel changes: (mainly merging from my local repo)
- Shared-memory feature. VKernel <->VM(including DOM0) 4MB regions. DOM0 has all regions Mapped.
- I/O Capabilities: for DOM0<->VM communication.

TODO: (I'll keep working on these in parallel)
- Capabilities for Distributed Tcaps, scheduling with Distributed tcaps, Distinction in Blocking/Yielding VMs.
- Chronos separation (Need to think how to best keep different scheduling models, plug and play kind).
- Microbenchmarks for Tcaps API, Interrupt latency
- Cross-component benchmarks.
- Other bugfixes, design changes in scheduling, etc.
- Synchronization library, Ring-buffer implementation, etc (Perhaps Robbie will do this as part of bringing RK to mainline.)

### Code Quality

As part of this pull request, I've considered the following:

Style:

- [x] Comments adhere to the Style Guide (SG)
- [x] Spacing adhere's to the SG 
- [x] Naming adhere's to the SG
- [x] All other aspects of the SG are adhered to, or exceptions are justified in this pull request

Code Craftsmanship:

- [x] I've made an attempt to remove all redundant code
- [x] I've considered ways in which my changes might impact existing code, and cleaned it up
- [x] I've formatted the code in an effort to make it easier to read (proper error handling, function use, etc...)
- [x] I've commented appropriately where code is tricky
- [x] I agree that there is no "throw-away" code, and that code in this PR is of high quality : **NOT OF HIGHEST QUALITY: vkernel changes for shared-memory and i/o caps not tested, requires it to be plugged in with RK env for the same.**
