### PR TITLE
Review Request: Default API proposed changes

### DIFF
--- a/src/components/include/cos_component.h
+++ b/src/components/include/cos_component.h
@@ -527,8 +527,10 @@ struct cos_array { char *mem; int sz; }; /* TODO: remove */
 #endif
 
 struct __thd_init_data {
-	void *fn;
-	void *data;
+	int     type;
+	void   *fn;
+	capid_t rcv;
+	void   *data;
 };
 
 #endif

--- a/src/components/interface/sched/cos_thd_creation.h
+++ b/src/components/interface/sched/cos_thd_creation.h
@@ -32,7 +32,7 @@ cos_thd_create(void *fn, void *data, u32_t sched_param0, u32_t sched_param1, u32
 
 	if (!fn) return 0;
 
-	idx = __init_data_alloc(fn, data);
+	idx = __init_data_alloc(fn, THD_NORMAL, 0, data);
 	assert(idx);
 	return sched_create_thd(idx << 16 | spdid, sched_param0, sched_param1, sched_param2);
 }

--- a/src/kernel/include/shared/cos_types.h
+++ b/src/kernel/include/shared/cos_types.h
@@ -178,6 +178,12 @@ typedef enum {
 	HW_LAPIC_TIMER = 255,  /* Local APIC TSC-DEADLINE mode - Timer interrupts */
 } hwid_t;
 
+typedef enum {
+	THD_NONE = 0,
+	THD_NORMAL,
+	THD_AEP,
+} thd_type_t;
+
 typedef unsigned long capid_t;
 #define TCAP_PRIO_MAX (1ULL)
 #define TCAP_PRIO_MIN ((~0ULL) >> 16) /* 48bit value */


### PR DESCRIPTION
* API revised for 2nd draft.
* Current thread function is not changed.
* TODO: a way to avoid increase in memory for __thd_init_data.

### Summary of this PR

Review request for New Default API. 
Current thread functions are not changed, they are typed `THD_NORMAL` in the `__thd_init_data` struct and the new typed thread are `THD_AEP`. 
I still need to think about a way to avoid having `rcvcap` and `type` in `__thd_init_data`, I could not find a solution yet. 
**TODO: API definition.**

### Code Quality

As part of this pull request, I've considered the following:

Style:

- [+] Comments adhere to the Style Guide (SG)
- [+] Spacing adhere's to the SG 
- [+] Naming adhere's to the SG
- [+] All other aspects of the SG are adhered to, or exceptions are justified in this pull request

Code Craftsmanship: **TODO**

- [ ] I've made an attempt to remove all redundant code
- [ ] I've considered ways in which my changes might impact existing code, and cleaned it up
- [ ] I've formatted the code in an effort to make it easier to read (proper error handling, function use, etc...)
- [ ] I've commented appropriately where code is tricky
- [ ] I agree that there is no "throw-away" code, and that code in this PR is of high quality
