### PR TITLE
curr_defci initialization status, cycles threshold for timer type and kernel api

### DIFF
--- a/src/components/implementation/tests/micro_booter/mb_tests.c
+++ b/src/components/implementation/tests/micro_booter/mb_tests.c
@@ -363,7 +363,8 @@ test_timer(void)
 		while (cos_sched_rcv(BOOT_CAPTBL_SELF_INITRCV_BASE, &tid, &blocked, &cycles) != 0) ;
 	}
 
-	PRINTC("\tCycles per tick (1000 microseconds) = %lld\n", t/16);
+	PRINTC("\tCycles per tick (1000 microseconds) = %lld, cycles threshold = %u\n",
+	       t/16, (unsigned int)cos_hw_cycles_thresh(BOOT_CAPTBL_SELF_INITHW_BASE));
 
 	PRINTC("Timer test completed.\nSuccess.\n");
 }

--- a/src/components/include/cos_kernel_api.h
+++ b/src/components/include/cos_kernel_api.h
@@ -106,6 +106,6 @@ int cos_hw_attach(hwcap_t hwc, hwid_t hwid, arcvcap_t rcvcap);
 int cos_hw_detach(hwcap_t hwc, hwid_t hwid);
 void *cos_hw_map(struct cos_compinfo *ci, hwcap_t hwc, paddr_t pa, unsigned int len);
 int cos_hw_cycles_per_usec(hwcap_t hwc);
-
+int cos_hw_cycles_thresh(hwcap_t hwc);
 
 #endif /* COS_KERNEL_API_H */

--- a/src/components/lib/cos_kernel_api.c
+++ b/src/components/lib/cos_kernel_api.c
@@ -818,6 +818,10 @@ cos_hw_cycles_per_usec(hwcap_t hwc)
 	return cycs;
 }
 
+int
+cos_hw_cycles_thresh(hwcap_t hwc)
+{ return call_cap_op(hwc, CAPTBL_OP_HW_CYC_THRESH, 0, 0, 0, 0); }
+
 void *
 cos_hw_map(struct cos_compinfo *ci, hwcap_t hwc, paddr_t pa, unsigned int len)
 {

--- a/src/kernel/capinv.c
+++ b/src/kernel/capinv.c
@@ -1589,6 +1589,11 @@ composite_syscall_slowpath(struct pt_regs *regs, int *thd_switch)
 			ret = chal_cyc_usec();
 			break;
 		}
+		case CAPTBL_OP_HW_CYC_THRESH:
+		{
+			ret = (int)chal_cyc_thresh();
+			break;
+		}
 		default: goto err;
 		}
 		break;

--- a/src/kernel/include/chal.h
+++ b/src/kernel/include/chal.h
@@ -84,6 +84,7 @@ PERCPU_DECL(struct cap_arcv *, cos_timer_arcv);
  *******************/
 
 int chal_cyc_usec(void);
+unsigned int chal_cyc_thresh(void);
 
 int chal_attempt_arcv(struct cap_arcv *arcv);
 int chal_attempt_ainv(struct async_cap *acap);

--- a/src/kernel/include/shared/cos_types.h
+++ b/src/kernel/include/shared/cos_types.h
@@ -57,10 +57,9 @@ tcap_cyc2time(cycles_t c) {
 	tcap_time_t t = (tcap_time_t)(c >> TCAP_TIME_QUANTUM_ORD);
 	return t == TCAP_TIME_NIL ? 1 : t;
 }
-#define CYCLES_DIFF_THRESH (1<<14)
 static inline int
-cycles_same(cycles_t a, cycles_t b)
-{ return (b < a ? a - b : b - a) <= CYCLES_DIFF_THRESH; }
+cycles_same(cycles_t a, cycles_t b, cycles_t diff_thresh)
+{ return (b < a ? a - b : b - a) <= diff_thresh; }
 /* FIXME: if wraparound happens, we need additional logic to compensate here */
 static inline int tcap_time_lessthan(tcap_time_t a, tcap_time_t b) { return a < b; }
 
@@ -117,7 +116,8 @@ typedef enum {
 	CAPTBL_OP_HW_ATTACH,
 	CAPTBL_OP_HW_DETACH,
 	CAPTBL_OP_HW_MAP,
-	CAPTBL_OP_HW_CYC_USEC
+	CAPTBL_OP_HW_CYC_USEC,
+	CAPTBL_OP_HW_CYC_THRESH,
 } syscall_op_t;
 
 typedef enum {

--- a/src/kernel/include/tcap.h
+++ b/src/kernel/include/tcap.h
@@ -118,6 +118,10 @@ tcap_active_next(struct cos_cpu_local_info *cli) { return (struct tcap *)list_fi
 static inline void
 tcap_active_rem(struct tcap *t) { list_rem(&t->active_list); }
 
+static unsigned int
+tcap_cycles_same(cycles_t a, cycles_t b)
+{ return cycles_same(a, b, (cycles_t)chal_cyc_thresh()); }
+
 /**
  * Expend @cycles amount of budget.
  * Return the amount of budget that is left in the tcap.
@@ -127,7 +131,7 @@ tcap_consume(struct tcap *t, tcap_res_t cycles)
 {
 	assert(t);
 	if (TCAP_RES_IS_INF(t->budget.cycles)) return 0;
-	if (cycles >= t->budget.cycles || cycles_same(cycles, t->budget.cycles)) {
+	if (cycles >= t->budget.cycles || tcap_cycles_same(cycles, t->budget.cycles)) {
 		t->budget.cycles = 0;
 		tcap_active_rem(t); /* no longer active */
 


### PR DESCRIPTION
### Summary of this PR

1. Initialization status for curr_defci, this allows library to detect invalid usage of API. 
2. `cycles_same` to take timer type into account, `ONESHOT` is less accurate than `TSC-DEADLINE`, taking that into account. Kernel API for users to access this threshold, this helps in cycle accounting at user-level. 

### Code Quality

As part of this pull request, I've considered the following:

Style:

- [x] Comments adhere to the Style Guide (SG)
- [x] Spacing adhere's to the SG 
- [x] Naming adhere's to the SG
- [x] All other aspects of the SG are adhered to, or exceptions are justified in this pull request

Code Craftsmanship:

- [x] I've made an attempt to remove all redundant code
- [x] I've considered ways in which my changes might impact existing code, and cleaned it up
- [x] I've formatted the code in an effort to make it easier to read (proper error handling, function use, etc...)
- [x] I've commented appropriately where code is tricky
- [x] I agree that there is no "throw-away" code, and that code in this PR is of high quality
