### PR TITLE
Add new boot component

### DIFF
--- a/src/components/implementation/no_interface/boot_test/Makefile
+++ b/src/components/implementation/no_interface/boot_test/Makefile
@@ -1,0 +1,10 @@
+C_OBJS=test_booter.o
+ASM_OBJS=
+COMPONENT=test_boot.o
+INTERFACES=
+DEPENDENCIES=
+IF_LIB=
+ADDITIONAL_LIBS=-lcobj_format -lcos_kernel_api
+
+include ../../Makefile.subsubdir
+MANDITORY_LIB=simple_stklib.o

--- a/src/components/implementation/no_interface/boot_test/boot_deps.h
+++ b/src/components/implementation/no_interface/boot_test/boot_deps.h
@@ -1,36 +1,9 @@
 #include <print.h>
+#include <cos_types.h>
 
 #undef assert
 #define assert(node) do { if (unlikely(!(node))) { debug_print("assert error in @ "); *((int *)0) = 0;} } while(0)
 
-//#include <mem_mgr.h>
-#include <sched.h>
-#include <cos_alloc.h>
-#include <cobj_format.h>
-#include <cos_types.h>
-
-static vaddr_t kmem_heap = BOOT_MEM_KM_BASE;
-static unsigned long n_kern_memsets = 0;
-
-//the booter uses this to keep track of each comp mapped in
-struct comp_cap_info {
-	struct cos_compinfo cos_compinfo;
-	vaddr_t addr_start;
-	vaddr_t vaddr_mapped_in_booter;
-	vaddr_t upcall_entry;
-};
-struct comp_cap_info comp_cap_info[MAX_NUM_SPDS+1];
-
-void
-cos_upcall_fn(upcall_type_t t, void *arg1, void *arg2, void *arg3)
-{
-	cos_init();	
-	return;
-}
-
-#define CAP_ID_32B_FREE BOOT_CAPTBL_FREE            // goes up
-#define CAP_ID_64B_FREE ((PAGE_SIZE*BOOT_CAPTBL_NPAGES - PAGE_SIZE/2)/16 - CAP64B_IDSZ) // goes down
-
 enum{
-       	BOOT_SINV_CAP = round_up_to_pow2(CAP_ID_32B_FREE + CAP32B_IDSZ, CAPMAX_ENTRY_SZ)
+       	BOOT_SINV_CAP = round_up_to_pow2(BOOT_CAPTBL_FREE  + CAP32B_IDSZ, CAPMAX_ENTRY_SZ)
 };

--- a/src/components/implementation/no_interface/boot_test/boot_deps.h
+++ b/src/components/implementation/no_interface/boot_test/boot_deps.h
@@ -1,0 +1,36 @@
+#include <print.h>
+
+#undef assert
+#define assert(node) do { if (unlikely(!(node))) { debug_print("assert error in @ "); *((int *)0) = 0;} } while(0)
+
+//#include <mem_mgr.h>
+#include <sched.h>
+#include <cos_alloc.h>
+#include <cobj_format.h>
+#include <cos_types.h>
+
+static vaddr_t kmem_heap = BOOT_MEM_KM_BASE;
+static unsigned long n_kern_memsets = 0;
+
+//the booter uses this to keep track of each comp mapped in
+struct comp_cap_info {
+	struct cos_compinfo cos_compinfo;
+	vaddr_t addr_start;
+	vaddr_t vaddr_mapped_in_booter;
+	vaddr_t upcall_entry;
+};
+struct comp_cap_info comp_cap_info[MAX_NUM_SPDS+1];
+
+void
+cos_upcall_fn(upcall_type_t t, void *arg1, void *arg2, void *arg3)
+{
+	cos_init();	
+	return;
+}
+
+#define CAP_ID_32B_FREE BOOT_CAPTBL_FREE            // goes up
+#define CAP_ID_64B_FREE ((PAGE_SIZE*BOOT_CAPTBL_NPAGES - PAGE_SIZE/2)/16 - CAP64B_IDSZ) // goes down
+
+enum{
+       	BOOT_SINV_CAP = round_up_to_pow2(CAP_ID_32B_FREE + CAP32B_IDSZ, CAPMAX_ENTRY_SZ)
+};

--- a/src/components/implementation/no_interface/boot_test/test_booter.c
+++ b/src/components/implementation/no_interface/boot_test/test_booter.c
@@ -1,0 +1,51 @@
+#include <stdio.h>
+#include <string.h>
+
+#include <cos_component.h>
+#include <cobj_format.h>
+#include <cos_kernel_api.h>
+#include "boot_deps.h"
+
+static void
+cos_llprint(char *s, int len)
+{ call_cap(PRINT_CAP_TEMP, (int)s, len, 0, 0); }
+
+
+int
+prints(char *s)
+{
+		int len = strlen(s);
+
+		cos_llprint(s, len);
+
+		return len;
+}
+
+int __attribute__((format(printf,1,2)))
+printc(char *fmt, ...)
+{
+	  char s[128];
+  	  va_list arg_ptr;
+  	  int ret, len = 128;
+
+  	  va_start(arg_ptr, fmt);
+  	  ret = vsnprintf(s, len, fmt, arg_ptr);
+  	  va_end(arg_ptr);
+	  cos_llprint(s, ret);
+
+	  return ret;
+}
+
+void 
+cos_init(void)
+{
+	
+	prints("\n|*****************************|\n");
+	prints(" Wecome to test_boot component!\n");
+	prints("|*****************************|\n");
+	sinvcap_t sinv = 0;
+	compcap_t cc;
+	int sinv_ret = 0;
+//	sinv_ret = cos_sinv(BOOT_SINV_CAP);
+
+}

--- a/src/components/implementation/no_interface/boot_test/test_booter.c
+++ b/src/components/implementation/no_interface/boot_test/test_booter.c
@@ -1,15 +1,11 @@
 #include <stdio.h>
 #include <string.h>
-
-#include <cos_component.h>
-#include <cobj_format.h>
 #include <cos_kernel_api.h>
 #include "boot_deps.h"
 
 static void
 cos_llprint(char *s, int len)
 { call_cap(PRINT_CAP_TEMP, (int)s, len, 0, 0); }
-
 
 int
 prints(char *s)
@@ -39,13 +35,9 @@ printc(char *fmt, ...)
 void 
 cos_init(void)
 {
-	
 	prints("\n|*****************************|\n");
 	prints(" Wecome to test_boot component!\n");
 	prints("|*****************************|\n");
-	sinvcap_t sinv = 0;
-	compcap_t cc;
-	int sinv_ret = 0;
-//	sinv_ret = cos_sinv(BOOT_SINV_CAP);
-
+	
+	cos_sinv(BOOT_SINV_CAP);
 }

--- a/src/components/implementation/no_interface/new_boot/Makefile
+++ b/src/components/implementation/no_interface/new_boot/Makefile
@@ -1,0 +1,10 @@
+C_OBJS=ppos_booter.o
+ASM_OBJS=inv.o
+COMPONENT=ppos_boot.o
+INTERFACES=
+DEPENDENCIES=
+IF_LIB=
+ADDITIONAL_LIBS=-lcobj_format -lcos_kernel_api
+
+include ../../Makefile.subsubdir
+MANDITORY_LIB=simple_stklib.o

--- a/src/components/implementation/no_interface/new_boot/boot_deps.h
+++ b/src/components/implementation/no_interface/new_boot/boot_deps.h
@@ -1,0 +1,147 @@
+#include <print.h>
+
+#undef assert
+#define assert(node) do { if (unlikely(!(node))) { debug_print("assert error in @ "); *((int *)0) = 0;} } while(0)
+
+#include <cos_alloc.h>
+#include <cobj_format.h>
+#include <cos_types.h>
+
+/*the booter uses this to keep track of each comp*/
+struct comp_cap_info {
+	struct cos_compinfo cos_compinfo;
+	vaddr_t addr_start;
+	vaddr_t vaddr_mapped_in_booter;
+	vaddr_t upcall_entry;
+};
+struct comp_cap_info comp_cap_info[MAX_NUM_SPDS+1];
+
+struct cos_compinfo boot_info;
+
+thdcap_t schedule[MAX_NUM_SPDS+1];
+unsigned int cur_sched;
+
+static int
+boot_comp_map_memory(struct cobj_header *h, spdid_t spdid, pgtblcap_t pt)
+{
+	int i, j;
+	int flag;
+	vaddr_t dest_daddr, prev_map = 0;
+	int tot = 0, n_pte = 1;	
+	
+	struct cobj_sect *sect = cobj_sect_get(h, 0);
+	
+	/*Expand Page table, could do this faster*/
+	for(j = 0; j < (int)h->nsect; j++){
+		tot += cobj_sect_size(h, j);
+	}
+	printc("tot: %d\n", tot);
+	if (tot > SERVICE_SIZE) {
+		n_pte = tot / SERVICE_SIZE;
+		if(tot % SERVICE_SIZE) n_pte++;
+	}	
+	for(j = 0; j < n_pte; j++){
+		if (!__bump_mem_expand_range(&boot_info, pt, sect->vaddr, SERVICE_SIZE)) BUG();
+	}
+
+	/* We'll map the component into booter's heap. */
+	comp_cap_info[spdid].vaddr_mapped_in_booter = (vaddr_t)cos_get_heap_ptr();
+	
+	for (i = 0 ; i < h->nsect ; i++) {
+		int left;
+
+		sect = cobj_sect_get(h, i);
+		flag = MAPPING_RW;
+		if (sect->flags & COBJ_SECT_KMEM) {
+			flag |= MAPPING_KMEM;
+		}
+
+		dest_daddr = sect->vaddr;
+		left       = cobj_sect_size(h, i);
+		
+		/* previous section overlaps with this one, don't remap! */
+		if (round_to_page(dest_daddr) == prev_map) {
+			left -= (prev_map + PAGE_SIZE - dest_daddr);
+			dest_daddr = prev_map + PAGE_SIZE;
+		}
+
+		while (left > 0) {
+			vaddr_t addr = cos_page_bump_alloc(&boot_info);
+			assert(addr);
+			
+			if (cos_mem_alias_at(&comp_cap_info[spdid].cos_compinfo, dest_daddr, &boot_info, addr)) BUG();
+			prev_map = dest_daddr;
+			dest_daddr += PAGE_SIZE;
+			left       -= PAGE_SIZE;
+		}
+	}
+
+	return 0;
+}
+
+void
+cos_upcall_fn(upcall_type_t t, void *arg1, void *arg2, void *arg3)
+{
+	static int first = 1;
+	int i;
+	
+	printc("core %ld: <<cos_upcall_fn thd %d (type %d, CREATE=%d, DESTROY=%d, FAULT=%d)>>\n",
+	       cos_cpuid(), cos_get_thd_id(), t, COS_UPCALL_THD_CREATE, COS_UPCALL_DESTROY, COS_UPCALL_UNHANDLED_FAULT);
+
+	if (first) {
+		first = 0;
+		for(i = 0; i < MAX_NUM_SPDS; i++){
+			schedule[i] = NULL;
+		}
+		__alloc_libc_initilize();
+		constructors_execute();
+		cur_sched = 0;
+	}
+
+	switch (t) {
+	case COS_UPCALL_THD_CREATE:
+	{
+		/* arg1 is the thread init data. 0 means
+		 * bootstrap. */
+		if (arg1 == 0) {
+			cos_init(NULL);
+		}
+	
+		cos_thd_switch(schedule[cur_sched]);
+	
+		return;
+	}
+	default:
+		/* fault! */
+		*(int*)NULL = 0;
+		return;
+	}
+	
+	return;
+}
+
+#define CAP_ID_32B_FREE BOOT_CAPTBL_FREE            // goes up
+capid_t capid_32b_free = CAP_ID_32B_FREE;
+
+/*Macro for sinv back to booter from new component*/
+enum{
+       	BOOT_SINV_CAP = round_up_to_pow2(CAP_ID_32B_FREE + CAP32B_IDSZ, CAPMAX_ENTRY_SZ)
+};
+
+
+void
+boot_thd_done(void)
+{
+	printc("\nWelcome back to the booter!\n");
+	cur_sched++;
+
+	if (schedule[cur_sched] != NULL) {
+		printc("Initializing comp: %d\n", cur_sched);
+	       	cos_thd_switch(schedule[cur_sched]);
+	} else {
+	       	printc("Done Initializing\n");
+	}
+
+	printc("What to do now... hm..\n");
+}
+

--- a/src/components/implementation/no_interface/new_boot/inv.S
+++ b/src/components/implementation/no_interface/new_boot/inv.S
@@ -9,9 +9,9 @@
 __inv_test_entry:
 	COS_ASM_GET_STACK
 
-        call boot_thd_done
+	call boot_thd_done
 
 	COS_ASM_RET_STACK
-        movl %eax, %ecx
-        movl $RET_CAP, %eax
-        sysenter;
+	movl %eax, %ecx
+	movl $RET_CAP, %eax
+	sysenter;

--- a/src/components/implementation/no_interface/new_boot/inv.S
+++ b/src/components/implementation/no_interface/new_boot/inv.S
@@ -1,0 +1,17 @@
+/* Use the passed in stack in arg4 */
+
+#include <cos_asm_simple_stacks.h>
+
+#define RET_CAP (1 << 16)
+.text
+.globl __inv_test_entry
+.type  __inv_test_entry, @function
+__inv_test_entry:
+	COS_ASM_GET_STACK
+
+        call boot_thd_done
+
+	COS_ASM_RET_STACK
+        movl %eax, %ecx
+        movl $RET_CAP, %eax
+        sysenter;

--- a/src/components/implementation/no_interface/new_boot/ppos_booter.c
+++ b/src/components/implementation/no_interface/new_boot/ppos_booter.c
@@ -1,0 +1,323 @@
+/*
+ *TODO:
+ *	Test Scheduling Array for dependencies 
+ */
+
+#include <stdio.h>
+#include <string.h>
+
+#include <cos_component.h>
+#include <cobj_format.h>
+#include <cos_kernel_api.h>
+#include <boot_deps.h>
+
+/*Assembly function for sinv from new component*/
+extern void *__inv_test_entry(int a, int b, int c);
+struct cos_compinfo boot_info;	
+
+struct cobj_header *hs[MAX_NUM_SPDS+1];
+
+struct deps {
+	short int client, server;
+};
+struct deps *deps;
+int ndeps;
+
+static void
+cos_llprint(char *s, int len)
+{ call_cap(PRINT_CAP_TEMP, (int)s, len, 0, 0); }
+
+int
+prints(char *s)
+{
+		int len = strlen(s);
+		cos_llprint(s, len);
+		return len;
+}
+
+int __attribute__((format(printf,1,2)))
+printc(char *fmt, ...)
+{
+	  char s[128];
+  	  va_list arg_ptr;
+  	  int ret, len = 128;
+
+  	  va_start(arg_ptr, fmt);
+  	  ret = vsnprintf(s, len, fmt, arg_ptr);
+  	  va_end(arg_ptr);
+	  cos_llprint(s, ret);
+
+	  return ret;
+}
+
+/*Component init info*/
+#define INIT_STR_SZ 52
+struct component_init_str {
+        unsigned int spdid, schedid;
+        int startup;
+        char init_str[INIT_STR_SZ];
+}__attribute__((packed));
+
+struct component_init_str *init_args;
+
+unsigned int *boot_sched;
+
+static void
+boot_find_cobjs(struct cobj_header *h, int n)
+{
+	int i;
+	vaddr_t start, end;
+
+	start = (vaddr_t)h;
+	hs[0] = h;
+
+	for (i = 1 ; i < n ; i++) {
+		int j = 0, size = 0, tot = 0;
+
+		size = h->size;
+		for (j = 0 ; j < (int)h->nsect ; j++) {
+			tot += cobj_sect_size(h, j);
+		}
+		printc("cobj %s:%d found at %p:%x, size %x -> %x\n",
+		       h->name, h->id, hs[i-1], size, tot, cobj_sect_get(hs[i-1], 0)->vaddr);
+
+		end   = start + round_up_to_cacheline(size);
+		hs[i] = h = (struct cobj_header*)end;
+		start = end;
+	}
+	
+	hs[n] = NULL;
+	printc("cobj %s:%d found at %p -> %x\n",
+	       hs[n-1]->name, hs[n-1]->id, hs[n-1], cobj_sect_get(hs[n-1], 0)->vaddr);
+}
+
+static vaddr_t
+boot_spd_end(struct cobj_header *h)
+{
+	struct cobj_sect *sect;
+	int max_sect;
+
+	max_sect = h->nsect-1;
+	sect     = cobj_sect_get(h, max_sect);
+
+	return sect->vaddr + round_up_to_page(sect->bytes);
+}
+
+static int
+boot_spd_symbs(struct cobj_header *h, spdid_t spdid, vaddr_t *comp_info)
+{
+//	printc("boot_spd_symbs: %d \n", h->nsymb);
+	int i = 0;
+	for(i = 0; i < h->nsymb; i++) {
+		struct cobj_symb *symb;
+
+		symb = cobj_symb_get(h, i);
+		assert(symb);
+		if (COBJ_SYMB_UNDEF == symb->type) break;
+
+		switch (symb->type) {
+		case COBJ_SYMB_COMP_INFO:
+			printc("Found comp_info\n");
+			*comp_info = symb->vaddr;
+			break;
+		default:
+			printc("boot: Unknown symbol type %d\n", symb->type);
+			break;
+		}
+
+	}
+	return 0;
+}
+
+static int
+boot_process_cinfo(struct cobj_header *h, spdid_t spdid, vaddr_t heap_val,
+		   char *mem, vaddr_t symb_addr)
+{
+	int i;
+	struct cos_component_information *ci;
+
+	assert(symb_addr == round_to_page(symb_addr));
+	ci = (struct cos_component_information*)(mem);
+
+	if (!ci->cos_heap_ptr) ci->cos_heap_ptr = heap_val;
+	
+	ci->cos_this_spd_id = spdid;
+	ci->init_string[0]  = '\0';
+	
+	for (i = 0 ; init_args[i].spdid ; i++) {
+		char *start, *end;
+		int len;
+
+		if (init_args[i].spdid != spdid) continue;
+
+		start = strchr(init_args[i].init_str, '\'');
+		if (!start) break;
+		start++;
+		end   = strchr(start, '\'');
+		if (!end) break;
+		len   = (int)(end-start);
+		memcpy(&ci->init_string[0], start, len);
+		ci->init_string[len] = '\0';
+	}
+
+	return 1;
+}
+
+static int
+boot_comp_map_populate(struct cobj_header *h, spdid_t spdid, vaddr_t comp_info, int first_time)
+{
+	unsigned int i;
+	/* Where are we in the actual component's memory in the booter? */
+	char *start_addr, *offset;
+	/* Where are we in the destination address space? */
+	vaddr_t prev_daddr, init_daddr;
+	struct cos_component_information *ci;
+
+	start_addr = (char *)(comp_cap_info[spdid].vaddr_mapped_in_booter);
+	init_daddr = cobj_sect_get(h, 0)->vaddr;
+	for (i = 0 ; i < h->nsect ; i++) {
+		struct cobj_sect *sect;
+		vaddr_t dest_daddr;
+		char *lsrc, *dsrc;
+		int left, dest_doff;
+
+		sect       = cobj_sect_get(h, i);
+		/* virtual address in the destination address space */
+		dest_daddr = sect->vaddr;
+		/* where we're copying from in the cobj */
+		lsrc       = cobj_sect_contents(h, i);
+		/* how much is left to copy? */
+		left       = cobj_sect_size(h, i);
+
+		/* Initialize memory. */
+		if (!(sect->flags & COBJ_SECT_KMEM) &&
+		    (first_time || !(sect->flags & COBJ_SECT_INITONCE))) {
+			if (sect->flags & COBJ_SECT_ZEROS) {
+      				memset(start_addr + (dest_daddr - init_daddr), 0, left);
+			} else {
+				memcpy(start_addr + (dest_daddr - init_daddr), lsrc, left);
+			}
+		}
+
+		if (sect->flags & COBJ_SECT_CINFO) {
+			assert(left == PAGE_SIZE);
+			assert(comp_info == dest_daddr);
+			boot_process_cinfo(h, spdid, boot_spd_end(h), start_addr + (comp_info-init_daddr), comp_info);
+			ci = (struct cos_component_information*)(start_addr + (comp_info-init_daddr));
+			comp_cap_info[h->id].upcall_entry = ci->cos_upcall_entry;
+			
+			vaddr_t begin =start_addr + ((ci->cos_upcall_entry) - init_daddr); 
+		}
+	
+	}
+
+	return 0;
+}
+
+static int
+boot_comp_map(struct cobj_header *h, spdid_t spdid, vaddr_t comp_info, pgtblcap_t pt)
+{
+	boot_comp_map_memory(h, spdid, pt);
+	boot_comp_map_populate(h, spdid, comp_info, 1);
+	return 0;
+}
+
+static void
+boot_create_cap_system(void)
+{
+	unsigned int i;
+
+
+	for(i = 0; hs[i] != NULL; i++){
+		
+		struct cobj_header *h;
+		struct cobj_sect *sect;
+		captblcap_t ct;
+		pgtblcap_t pt;
+		compcap_t cc;
+		spdid_t spdid;
+		capid_t pte_cap;
+		vaddr_t ci = 0;
+		
+		h = hs[i];
+		spdid = h->id;
+		printc("Initializing Comp: %s\n", h->name);	
+		
+		sect = cobj_sect_get(h, 0);
+		comp_cap_info[spdid].addr_start = sect->vaddr;
+		
+		ct = cos_captbl_alloc(&boot_info);
+		assert(ct);	
+		pt = cos_pgtbl_alloc(&boot_info);
+		assert(pt);	
+		
+		/*The comp_cap is not alloc'd yet, due to hack for upcall_fn*/
+		cos_compinfo_init(&comp_cap_info[spdid].cos_compinfo, pt, ct, 0, 
+				  (vaddr_t)sect->vaddr, 4, &boot_info);
+		
+		if (boot_spd_symbs(h, spdid, &ci)) BUG();
+		if (boot_comp_map(h, spdid, ci, pt))   BUG();
+	        	
+		cc = cos_comp_alloc(&boot_info, ct, pt, (vaddr_t)comp_cap_info[spdid].upcall_entry);
+		assert(cc);	
+		comp_cap_info[spdid].cos_compinfo.comp_cap = cc;
+	
+		/* Create sinv capability from Userspace to Booter components */
+		/* Need id 1 because we need to wait for id 0 to finish initializing */
+		sinvcap_t sinv;
+
+		sinv = cos_sinv_alloc(&boot_info, boot_info.comp_cap, (vaddr_t)__inv_test_entry);
+		assert(sinv > 0);
+		printc("sinv: %d\n", sinv);
+
+		/* Copy into vm0 capability table at a known location */
+		cos_cap_cpy_at(&comp_cap_info[spdid].cos_compinfo, BOOT_SINV_CAP, &boot_info, sinv);
+
+		printc("Comp %d (%s) activated @ %x!\n", h->id, h->name, sect->vaddr);
+		
+		thdcap_t main_thd = cos_initthd_alloc(&boot_info, cc);
+		assert(main_thd);
+		
+		i = 0;
+		while(schedule[i] != NULL){
+			i++;
+		}
+		schedule[i] = main_thd;
+	}
+
+	return;
+}
+			
+void 
+cos_init(void)
+{
+
+	printc("Booter for new kernel\n");
+
+ 	struct cobj_header *h;
+	int num_cobj, i;
+
+	h         = (struct cobj_header *)cos_comp_info.cos_poly[0];
+	num_cobj  = (int)cos_comp_info.cos_poly[1];
+
+	deps      = (struct deps *)cos_comp_info.cos_poly[2];
+	for (i = 0 ; deps[i].server ; i++) ;
+	ndeps     = i;
+	
+	init_args = (struct component_init_str *)cos_comp_info.cos_poly[3];
+	init_args++;
+
+	boot_sched = (unsigned int *)cos_comp_info.cos_poly[4];
+	
+	boot_find_cobjs(h, num_cobj);
+
+	cos_meminfo_init(&boot_info.mi, BOOT_MEM_KM_BASE, COS_MEM_KERN_PA_SZ, BOOT_CAPTBL_SELF_UNTYPED_PT);
+	
+	cos_compinfo_init(&boot_info, BOOT_CAPTBL_SELF_PT, BOOT_CAPTBL_SELF_CT, BOOT_CAPTBL_SELF_COMP, 
+			(vaddr_t)cos_get_heap_ptr(), BOOT_CAPTBL_FREE, &boot_info);
+
+	boot_create_cap_system();
+	printc("booter: done creating system.\n");
+
+}
+

--- a/src/components/implementation/no_interface/new_boot/ppos_booter.c
+++ b/src/components/implementation/no_interface/new_boot/ppos_booter.c
@@ -80,6 +80,61 @@ boot_find_cobjs(struct cobj_header *h, int n)
 	       hs[n-1]->name, hs[n-1]->id, hs[n-1], cobj_sect_get(hs[n-1], 0)->vaddr);
 }
 
+static int
+boot_comp_map_memory(struct cobj_header *h, spdid_t spdid, pgtblcap_t pt)
+{
+	int i, j;
+	int flag;
+	vaddr_t dest_daddr, prev_map = 0;
+	int tot = 0, n_pte = 1;	
+	struct cobj_sect *sect = cobj_sect_get(h, 0);
+	
+	/* Expand Page table, could do this faster */
+	for (j = 0 ; j < (int)h->nsect ; j++) {
+		tot += cobj_sect_size(h, j);
+	}
+	
+	if (tot > SERVICE_SIZE) {
+		n_pte = tot / SERVICE_SIZE;
+		if (tot % SERVICE_SIZE) n_pte++;
+	}	
+	
+	boot_comp_pgtbl_expand(n_pte, pt, sect->vaddr);
+
+	/* We'll map the component into booter's heap. */
+	new_comp_cap_info[spdid].vaddr_mapped_in_booter = (vaddr_t)cos_get_heap_ptr();
+	
+	for (i = 0 ; i < h->nsect ; i++) {
+		int left;
+
+		sect = cobj_sect_get(h, i);
+		flag = MAPPING_RW;
+		if (sect->flags & COBJ_SECT_KMEM) {
+			flag |= MAPPING_KMEM;
+		}
+
+		dest_daddr = sect->vaddr;
+		left       = cobj_sect_size(h, i);
+		
+		/* previous section overlaps with this one, don't remap! */
+		if (round_to_page(dest_daddr) == prev_map) {
+			left -= (prev_map + PAGE_SIZE - dest_daddr);
+			dest_daddr = prev_map + PAGE_SIZE;
+		}
+
+		while (left > 0) {
+			boot_comp_mmap(spdid, dest_daddr);
+
+			prev_map = dest_daddr;
+			dest_daddr += PAGE_SIZE;
+			left       -= PAGE_SIZE;
+		}
+	}
+
+	return 0;
+}
+
+			
 static vaddr_t
 boot_spd_end(struct cobj_header *h)
 {
@@ -240,6 +295,16 @@ boot_create_cap_system(void)
 
 	return;
 }
+
+static void
+boot_init_sched(void)
+{
+	int i;
+	
+	for (i = 0 ; i < MAX_NUM_SPDS ; i++) schedule[i] = NULL;
+	sched_cur = 0;
+}
+
 			
 void
 boot_init_ndeps(void)

--- a/src/components/include/cos_kernel_api.h
+++ b/src/components/include/cos_kernel_api.h
@@ -51,6 +51,7 @@ void cos_compinfo_init(struct cos_compinfo *ci, pgtblcap_t pgtbl_cap, captblcap_
  */
 void cos_meminfo_init(struct cos_meminfo *mi, vaddr_t untyped_ptr, unsigned long untyped_sz, pgtblcap_t pgtbl_cap);
 void cos_meminfo_alloc(struct cos_compinfo *ci, vaddr_t untyped_ptr, unsigned long untyped_sz);
+vaddr_t __bump_mem_expand_range(struct cos_compinfo *ci, pgtblcap_t cipgtbl, vaddr_t mem_ptr, unsigned long mem_sz);
 
 /*
  * This uses the next three functions to allocate a new component and

--- a/src/components/include/cos_kernel_api.h
+++ b/src/components/include/cos_kernel_api.h
@@ -51,7 +51,7 @@ void cos_compinfo_init(struct cos_compinfo *ci, pgtblcap_t pgtbl_cap, captblcap_
  */
 void cos_meminfo_init(struct cos_meminfo *mi, vaddr_t untyped_ptr, unsigned long untyped_sz, pgtblcap_t pgtbl_cap);
 void cos_meminfo_alloc(struct cos_compinfo *ci, vaddr_t untyped_ptr, unsigned long untyped_sz);
-vaddr_t __bump_mem_expand_range(struct cos_compinfo *ci, pgtblcap_t cipgtbl, vaddr_t mem_ptr, unsigned long mem_sz);
+vaddr_t cos_pgtbl_intern_alloc(struct cos_compinfo *ci, pgtblcap_t cipgtbl, vaddr_t mem_ptr, unsigned long mem_sz);
 
 /*
  * This uses the next three functions to allocate a new component and
@@ -88,6 +88,8 @@ int cos_rcv(arcvcap_t rcv);
 int cos_sched_rcv(arcvcap_t rcv, thdid_t *thdid, int *blocked, cycles_t *cycles);
 
 int cos_introspect(struct cos_compinfo *ci, capid_t cap, unsigned long op);
+
+int cos_sinv(sinvcap_t sinv);
 
 vaddr_t cos_mem_alias(struct cos_compinfo *dstci, struct cos_compinfo *srcci, vaddr_t src);
 int cos_mem_alias_at(struct cos_compinfo *dstci, vaddr_t dst, struct cos_compinfo *srcci, vaddr_t src);

--- a/src/components/lib/cos_kernel_api.c
+++ b/src/components/lib/cos_kernel_api.c
@@ -282,7 +282,7 @@ __capid_bump_alloc(struct cos_compinfo *ci, cap_t cap)
 
 /**************** [User Virtual Memory Allocation Functions] ****************/
 
-static vaddr_t
+vaddr_t
 __bump_mem_expand_range(struct cos_compinfo *ci, pgtblcap_t cipgtbl, vaddr_t mem_ptr, unsigned long mem_sz)
 {
 	vaddr_t addr;

--- a/src/components/lib/cos_kernel_api.c
+++ b/src/components/lib/cos_kernel_api.c
@@ -282,7 +282,8 @@ __capid_bump_alloc(struct cos_compinfo *ci, cap_t cap)
 
 /**************** [User Virtual Memory Allocation Functions] ****************/
 
-vaddr_t
+
+static vaddr_t
 __bump_mem_expand_range(struct cos_compinfo *ci, pgtblcap_t cipgtbl, vaddr_t mem_ptr, unsigned long mem_sz)
 {
 	vaddr_t addr;
@@ -316,6 +317,12 @@ __bump_mem_expand_range(struct cos_compinfo *ci, pgtblcap_t cipgtbl, vaddr_t mem
 	assert(round_up_to_pgd_page(addr) == round_up_to_pgd_page(mem_ptr + mem_sz));
 	
 	return mem_ptr;
+}
+
+vaddr_t
+cos_pgtbl_intern_alloc(struct cos_compinfo *ci, pgtblcap_t cipgtbl, vaddr_t mem_ptr, unsigned long mem_sz)
+{
+	return __bump_mem_expand_range(ci, cipgtbl, mem_ptr, mem_sz);
 }
 
 static void
@@ -555,6 +562,10 @@ cos_sinv_alloc(struct cos_compinfo *srcci, compcap_t dstcomp, vaddr_t entry)
 
 	return cap;
 }
+
+int
+cos_sinv(sinvcap_t sinv)
+{ return call_cap_op(sinv, 0, 0, 0, 0, 0); }
 
 /*
  * Arguments:

--- a/src/platform/i386/runscripts/ppos_boot.sh
+++ b/src/platform/i386/runscripts/ppos_boot.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+cp ppos_boot.o llboot.o
+./cos_linker "llboot.o, ;test_boot.o, :" ./gen_client_stub


### PR DESCRIPTION
Add new ppos_boot component that uses new cos_kernel_api
Modify cos_kernel_api to make __bump_mem_expand_range non static
Add a boot_test component+assembly files to test cos_sinv(), not currently supported in gparmer/composite repo
Mechanism for dependency based boot scheduling in place, but not tested

### Summary of this PR

Includes the /new_boot directory. Which includes ppos_booter.c and boot_deps.h.
The ppos_booter is a new version of the llbooter which uses the new cos_kernel_api.
I've added the script ppos_boot.sh for running the new booter. It boots a test component (found in /boot_test). The test component does cos_sinv() back into the booter before its cos_init() returns, but this is commented out currently, as the functionality isn't supported yet in the repo. 
Including:
@phanikishoreg @ryuxin 
for peer code review.

### Code Quality

As part of this pull request, I've considered the following:

Style:

- [x] Comments adhere to the Style Guide (SG)
- [x] Spacing adhere's to the SG 
- [x] Naming adhere's to the SG
- [x] All other aspects of the SG are adhered to, or exceptions are justified in this pull request

Code Craftsmanship:

- [x] I've made an attempt to remove all redundant code
- [x] I've considered ways in which my changes might impact existing code, and cleaned it up
- [x] I've formatted the code in an effort to make it easier to read (proper error handling, function use, etc...)
- [x] I've commented appropriately where code is tricky
- [x] I agree that there is no "throw-away" code, and that code in this PR is of high quality
