### PR TITLE
Fix compilation warnings

### DIFF
--- a/src/components/implementation/no_interface/new_boot/boot_deps.h
+++ b/src/components/implementation/no_interface/new_boot/boot_deps.h
@@ -33,7 +33,7 @@ enum {
 static vaddr_t
 boot_deps_map_sect(int spdid, vaddr_t dest_daddr)
 {
-	vaddr_t addr = cos_page_bump_alloc(&boot_info);
+	vaddr_t addr = (vaddr_t) cos_page_bump_alloc(&boot_info);
 	assert(addr);
 			
 	if (cos_mem_alias_at(new_comp_cap_info[spdid].compinfo, dest_daddr, &boot_info, addr)) BUG();
@@ -76,7 +76,7 @@ boot_compinfo_init(int spdid, captblcap_t *ct, pgtblcap_t *pt, u32_t vaddr)
 }
 
 static void
-boot_newcomp_create(int spdid, struct comp_cap_info *comp_info)
+boot_newcomp_create(int spdid, struct cos_compinfo *comp_info)
 {
 	compcap_t   cc;
 	captblcap_t ct = new_comp_cap_info[spdid].compinfo->captbl_cap;
@@ -100,7 +100,7 @@ boot_newcomp_create(int spdid, struct comp_cap_info *comp_info)
 	assert(main_thd);
 
 	/* Add created component to "scheduling" array */		
-	while (schedule[i] != NULL) i++;
+	while (schedule[i] != 0) i++;
 	schedule[i] = main_thd;
 }
 
@@ -126,7 +126,7 @@ boot_thd_done(void)
 {
 	sched_cur++;
 
-	if (schedule[sched_cur] != NULL) {
+	if (schedule[sched_cur] != 0) {
 		printc("Initializing comp: %d\n", sched_cur);
 	       	cos_thd_switch(schedule[sched_cur]);
 	} else {

--- a/src/components/implementation/no_interface/new_boot/ppos_booter.c
+++ b/src/components/implementation/no_interface/new_boot/ppos_booter.c
@@ -64,7 +64,7 @@ boot_comp_map_memory(struct cobj_header *h, spdid_t spdid, pgtblcap_t pt)
 	/* We'll map the component into booter's heap. */
 	new_comp_cap_info[spdid].vaddr_mapped_in_booter = (vaddr_t)cos_get_heap_ptr();
 	
-	for (i = 0 ; i < h->nsect ; i++) {
+	for (i = 0 ; i < (int)h->nsect ; i++) {
 		int left;
 
 		sect = cobj_sect_get(h, i);
@@ -112,7 +112,7 @@ boot_spd_symbs(struct cobj_header *h, spdid_t spdid, vaddr_t *comp_info)
 {
 	int i = 0;
 
-	for (i = 0 ; i < h->nsymb ; i++) {
+	for (i = 0 ; i < (int)h->nsymb ; i++) {
 		struct cobj_symb *symb;
 
 		symb = cobj_symb_get(h, i);
@@ -208,7 +208,7 @@ boot_comp_map_populate(struct cobj_header *h, spdid_t spdid, vaddr_t comp_info, 
 			ci = (struct cos_component_information*)(start_addr + (comp_info-init_daddr));
 			new_comp_cap_info[h->id].upcall_entry = ci->cos_upcall_entry;
 			
-			vaddr_t begin =start_addr + ((ci->cos_upcall_entry) - init_daddr); 
+			vaddr_t begin = (vaddr_t) start_addr + ((ci->cos_upcall_entry) - init_daddr); 
 		}
 	}
 
@@ -228,7 +228,7 @@ boot_init_sched(void)
 {
 	int i;
 	
-	for (i = 0 ; i < MAX_NUM_SPDS ; i++) schedule[i] = NULL;
+	for (i = 0 ; i < MAX_NUM_SPDS ; i++) schedule[i] = 0;
 	sched_cur = 0;
 }
 						


### PR DESCRIPTION
Fixed ppos_booter and boot_deps for trivial compilation warnings.

### Summary of this PR
Fix compilation warnings from boot component code. 

Add description here.
Sorry!!! Figured I should make this PR cause I made the changes anyways. 
Doesn't change any of the code's functionality, feel free to throw PR away if not necessary.

### Code Quality

As part of this pull request, I've considered the following:

Style:

- [x] Comments adhere to the Style Guide (SG)
- [x] Spacing adhere's to the SG 
- [x] Naming adhere's to the SG
- [x] All other aspects of the SG are adhered to, or exceptions are justified in this pull request

Code Craftsmanship:

- [x] I've made an attempt to remove all redundant code
- [x] I've considered ways in which my changes might impact existing code, and cleaned it up
- [x] I've formatted the code in an effort to make it easier to read (proper error handling, function use, etc...)
- [x] I've commented appropriately where code is tricky
- [x] I agree that there is no "throw-away" code, and that code in this PR is of high quality
