### PR TITLE
Bugfixes in timer-driver and schedlib sched_loop 

### DIFF
--- a/src/platform/i386/hpet.c
+++ b/src/platform/i386/hpet.c
@@ -116,14 +116,14 @@ static void
 timer_disable(timer_type_t timer_type)
 {
 	/* Disable timer interrupts */
-	*hpet_config ^= ~1;
+	*hpet_config &= ~HPET_ENABLE_CNF;
 
 	/* Disable timer interrupt of timer_type */
 	hpet_timers[timer_type].config = 0;
 	hpet_timers[timer_type].compare = 0;
 
 	/* Enable timer interrupts */
-	*hpet_config |= 1;
+	*hpet_config |= HPET_ENABLE_CNF;
 }
 
 static void
@@ -206,13 +206,13 @@ timer_set(timer_type_t timer_type, u64_t cycles)
 {
 	u64_t outconfig = TN_INT_TYPE_CNF | TN_INT_ENB_CNF;
 
-	cycles = timer_cpu2hpet_cycles(cycles);
-
 	/* Disable timer interrupts */
-	*hpet_config ^= ~1;
+	*hpet_config &= ~HPET_ENABLE_CNF;
 
 	/* Reset main counter */
 	if (timer_type == TIMER_ONESHOT) {
+		cycles = timer_cpu2hpet_cycles(cycles);
+
 		/* Set a static value to count up to */
 		hpet_timers[timer_type].config = outconfig;
 		cycles += HPET_COUNTER;
@@ -225,16 +225,8 @@ timer_set(timer_type_t timer_type, u64_t cycles)
 	hpet_timers[timer_type].compare = cycles;
 
 	/* Enable timer interrupts */
-	*hpet_config |= 1;
+	*hpet_config |= HPET_ENABLE_CNF;
 }
-
-/* FIXME:  This is broken. Why does setting the oneshot twice make it work? */
-/*void
-chal_timer_set(cycles_t cycles)
-{
-	timer_set(TIMER_ONESHOT, cycles);
-	timer_set(TIMER_ONESHOT, cycles);
-}*/
 
 u64_t
 timer_find_hpet(void *timer)
@@ -286,7 +278,7 @@ timer_init(void)
 
 	printk("Enabling timer @ %p with tick granularity %ld picoseconds\n", hpet, pico_per_hpetcyc);
 	/* Enable legacy interrupt routing */
-	*hpet_config |= (1ll);
+	*hpet_config |= HPET_LEG_RT_CNF;
 
 	/*
 	 * Set the timer as specified.  This assumes that the cycle

--- a/src/platform/i386/lapic.c
+++ b/src/platform/i386/lapic.c
@@ -38,11 +38,11 @@ enum lapic_timer_type {
 };
 
 enum lapic_timer_div_by_config {
-	LAPIC_DIV_BY_2 = 0,
+	LAPIC_DIV_BY_2  = 0,
 	LAPIC_DIV_BY_4,
 	LAPIC_DIV_BY_8,
 	LAPIC_DIV_BY_16,
-	LAPIC_DIV_BY_32,
+	LAPIC_DIV_BY_32 = 8,
 	LAPIC_DIV_BY_64,
 	LAPIC_DIV_BY_128,
 	LAPIC_DIV_BY_1,


### PR DESCRIPTION
### Summary of this PR

HPET timer configuration wasn't done right. Instead of using AND, we have had XOR for a while there. I'm still not sure how it worked fine for Oneshots (I need to think about how many times we XOR in that to see that it really worked because of that) but because we use it for initial Periodic timers, it was okay. Now, I had to fix bugs to make it work for reprogramming of periodic timers. 

LAPIC timer divide configuration was not set to right numbers, which is a bug but didn't impact much as we calibrate oneshots dynamically and use. So whichever divider it used, we were still programming oneshots using conversions required for such frequency!

Schedlib - sched_loop should consider child schedulers where there are events other than scheduling ones, mainly activations from the parent schedulers if they decide to use notification-based activations as opposed to simply context-switching to them. Also, if pending = 0, sched loop still need to process that one event that caused it to unblock, so fixed that as well. 

### Code Quality

As part of this pull request, I've considered the following:

Style:

- [x] Comments adhere to the Style Guide (SG)
- [x] Spacing adhere's to the SG 
- [x] Naming adhere's to the SG
- [x] All other aspects of the SG are adhered to, or exceptions are justified in this pull request

Code Craftsmanship:

- [x] I've made an attempt to remove all redundant code
- [x] I've considered ways in which my changes might impact existing code, and cleaned it up
- [x] I've formatted the code in an effort to make it easier to read (proper error handling, function use, etc...)
- [x] I've commented appropriately where code is tricky
- [x] I agree that there is no "throw-away" code, and that code in this PR is of high quality
