### PR TITLE
Bugfix in schedtests - missed to reset workiters

### DIFF
--- a/src/components/implementation/no_interface/scheddev/unit_schedlib.c
+++ b/src/components/implementation/no_interface/scheddev/unit_schedlib.c
@@ -54,10 +54,10 @@ printc(char *fmt, ...)
 void
 test_thd_fn(void *data)
 {
-	int workiters = WORKITERS * ((int)data);
 	while (1) {
-		SPIN(workiters);
+		int workiters = WORKITERS * ((int)data);
 
+		SPIN(workiters);
 		sl_thd_yield(0);
 	}
 }


### PR DESCRIPTION
### Summary of this PR

Biggest blunder, I didn't notice that the threads eventually run into a spin-forever loop because of this, instead of yielding after "doing work". Though this doesn't change anything, especially the timeout "working" because I had originally debugged/tested with an inline code for that loop/spin, also because I just double checked the working after fixing it. I should be more careful and will be. 

### Code Quality

As part of this pull request, I've considered the following:

Style:

- [x] Comments adhere to the Style Guide (SG)
- [x] Spacing adhere's to the SG 
- [x] Naming adhere's to the SG
- [x] All other aspects of the SG are adhered to, or exceptions are justified in this pull request

Code Craftsmanship:

- [x] I've made an attempt to remove all redundant code
- [x] I've considered ways in which my changes might impact existing code, and cleaned it up
- [x] I've formatted the code in an effort to make it easier to read (proper error handling, function use, etc...)
- [x] I've commented appropriately where code is tricky
- [x] I agree that there is no "throw-away" code, and that code in this PR is of high quality
