### PR TITLE
Change the src Makefile to use PLATFORM_ID instead of PLATFORM

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ tags
 src/kernel/include/shared/cpu_ghz.h
 src/Makefile.cosconfig
 src/PLATFORM
+src/PLATFORM_ID
 modules.order
 .depend
 *.img

--- a/src/Makefile
+++ b/src/Makefile
@@ -1,7 +1,7 @@
 MAKEFLAGS=--no-print-directory --section-alignment 0x1000 -I$(PWD)
 #$(info Make flags $(MAKEFLAGS))
 
-all: comps $(shell cat PLATFORM)
+all: comps $(shell cat PLATFORM_ID)
 
 comps:
 	$(info )
@@ -69,13 +69,13 @@ config-linux: config-gen
 	@echo "#define COS_PLATFORM LINUX" >> ./kernel/include/shared/cpu_ghz.h
 	@echo "#define COS_LINUX" >> ./kernel/include/shared/cpu_ghz.h
 	@cd kernel/include/ ; rm -f chal ; ln -s ../../platform/linux/module/chal/ chal
-	@echo "linux" > PLATFORM
+	@echo "linux" > PLATFORM_ID
 
 # override the default linux chal link
 config-i386: config-gen
 	@echo "#define COS_PLATFORM I386" >> ./kernel/include/shared/cpu_ghz.h
 	@cd kernel/include/ ; rm -f chal ; ln -s ../../platform/i386/chal/ chal
-	@echo "i386" > PLATFORM
+	@echo "i386" > PLATFORM_ID
 
 idl:
 	$(MAKE) $(MAKEFLAGS) -C components idl


### PR DESCRIPTION
### Summary of this PR
The src Makefile creates a temporary file that stores the name of
the platform the build is running on. (It does this when you run
`make config`.) This file was historically called PLATFORM, which
worked fine. However, there is a folder in the src directory
called `platform`. On case insensitive file systems this causes an
obvious problem. To fix this, I modified the Makefile to use
PLATFORM_ID instead.

### Code Quality

As part of this pull request, I've considered the following:

Style:
- [x] Comments adhere to the Style Guide (SG)
- [x] Spacing adhere's to the SG 
- [x] Naming adhere's to the SG
- [x] All other aspects of the SG are adhered to, or exceptions are justified in this pull request

Code Craftsmanship:
- [x] I've made an attempt to remove all redundant code
- [x] I've considered ways in which my changes might impact existing code, and cleaned it up
- [x] I've formatted the code in an effort to make it easier to read (proper error handling, function use, etc...)
- [x] I've commented appropriately where code is tricky
- [x] I agree that there is no "throw-away" code, and that code in this PR is of high quality
