### PR TITLE
Fix hardcoded stack size and alignment

### DIFF
--- a/src/components/Makefile.comp
+++ b/src/components/Makefile.comp
@@ -30,7 +30,7 @@ LUADIR=$(LUABASE)/lua-5.2.1
 LUAOBJ=$(LUABASE)/cos/lua_lang.o
 LUAINC=-I$(LUADIR)/src -I$(LUABASE)/cos/include
 
-INC_PATH=-I./ -I$(CDIR)/include/ -I$(CDIR)/interface/
+INC_PATH=-I./ -I$(CDIR)/include/ -I$(CDIR)/interface/ -I$(SHAREDINC)
 # FIXME: dietlibc is now compiled with fno merge constants which is
 # probably ballooning its size.  Fix this need for no merge constants
 # in cos_loader.

--- a/src/components/implementation/no_interface/new_boot/inv.S
+++ b/src/components/implementation/no_interface/new_boot/inv.S
@@ -1,8 +1,9 @@
 /* Use the passed in stack in arg4 */
 
+#define __ASM__
+#include <consts.h>
 #include <cos_asm_simple_stacks.h>
 
-#define RET_CAP (1 << 16)
 .text
 .globl __inv_test_entry
 .type  __inv_test_entry, @function

--- a/src/components/include/cos_asm_simple_stacks.h
+++ b/src/components/include/cos_asm_simple_stacks.h
@@ -1,13 +1,17 @@
 #ifndef COS_ASM_SIMPLE_STACKS_H
 #define COS_ASM_SIMPLE_STACKS_H
 
+#ifndef MAX_STACK_SZ_BYTE_ORDER
+#error "Missing MAX_STACK_SZ_BYTE_ORDER, try including consts.h"
+#endif
+
 #define COS_ASM_GET_STACK                   \
 	movl $cos_static_stack, %esp;	    \
 	movl %eax, %edx;		    \
 	andl $0xffff, %eax;		    \
-	shl $12, %eax;                      \
+	shl $MAX_STACK_SZ_BYTE_ORDER, %eax;                      \
 	addl %eax, %esp;		    \
-	shr $12, %eax;			    \
+	shr $MAX_STACK_SZ_BYTE_ORDER, %eax;			    \
 	shr $16, %edx;			    \
 	pushl %edx;			    \
 	pushl %eax;

--- a/src/components/interface/stkmgr/stubs/s_stub.S
+++ b/src/components/interface/stkmgr/stubs/s_stub.S
@@ -5,7 +5,8 @@
  * Public License v2.
  */
 
-
+#define __ASM__
+#include <consts.h>
 #include <cos_asm_server_stub_simple_stack.h>
 
 .text
@@ -22,5 +23,5 @@ cos_asm_server_stub(stkmgr_detect_suspension)
 cos_asm_server_stub(stkmgr_set_over_quota_limit)
 cos_asm_server_stub(stkmgr_set_suspension_limit)
 cos_asm_server_stub(stkmgr_get_allocated)
-	
+
 cos_asm_server_stub_spdid(stkmgr_stack_introspect)

--- a/src/components/lib/cos_asm_upcall_simple_stacks.S
+++ b/src/components/lib/cos_asm_upcall_simple_stacks.S
@@ -6,8 +6,8 @@
  */
 
 #define __ASM__
-#include <cos_asm_simple_stacks.h>
 #include <consts.h>
+#include <cos_asm_simple_stacks.h>
 #include "../../kernel/include/asm_ipc_defs.h"
 
 #define IPRETURN 4
@@ -20,6 +20,7 @@ nil:
 	.long 0
 	.endr
 
+.align COS_STACK_SZ
 .globl cos_static_stack
 cos_static_stack:
 	.rep ALL_STACK_SZ
@@ -27,7 +28,7 @@ cos_static_stack:
 	.endr
 .globl cos_static_stack_end
 cos_static_stack_end:
-	
+
 .text
 .globl cos_upcall_entry
 .type  cos_upcall_entry, @function
@@ -39,7 +40,7 @@ cos_upcall_entry:
 	pushl %edi
 	pushl %ebx
 	xor %ebp, %ebp
-	pushl %ecx /* option */	
+	pushl %ecx /* option */
 	call cos_upcall_fn
 	addl $16, %esp
 
@@ -48,7 +49,7 @@ cos_upcall_entry:
 	COS_ASM_RET_STACK
 
 	sysenter
-	
+
 /*
  * %eax = cmpval, %ebx = memaddr, %ecx = newval
  * output %edx, either cmpval: fail, or newval:	success
@@ -63,7 +64,7 @@ cos_atomic_cmpxchg:
 	movl %ecx, %edx   /* XXX */
 	movl %ecx, (%ebx)
 .weak cos_atomic_cmpxchg_end
-cos_atomic_cmpxchg_end:	
+cos_atomic_cmpxchg_end:
 	ret
 
 /*
@@ -92,4 +93,3 @@ cos_atomic_user4_end:
 	/* crash out as something's wrong */
 	movl $0, %eax
 	movl (%eax), %eax
-

--- a/src/kernel/include/shared/consts.h
+++ b/src/kernel/include/shared/consts.h
@@ -44,20 +44,25 @@ struct pt_regs {
 #endif
 #define PAGE_ORDER 12
 #ifndef __KERNEL__
-#define PAGE_SIZE (1<<PAGE_ORDER)
+#define PAGE_SIZE (1 << PAGE_ORDER)
 #endif
 
 #define MAX_SERVICE_DEPTH 31
 #define MAX_NUM_THREADS 64
+
 /* Stacks are 2 * page_size (expressed in words) */
-#define MAX_STACK_SZ    (PAGE_SIZE/4) /* a page */
-#define COS_STACK_SZ    (MAX_STACK_SZ*4)
-#define ALL_STACK_SZ    (MAX_NUM_THREADS*MAX_STACK_SZ)
+#define MAX_STACK_SZ_BYTE_ORDER 12
+/* Stack size in bytes */
+#define COS_STACK_SZ    (1 << MAX_STACK_SZ_BYTE_ORDER)
+/* Stack size in words */
+#define MAX_STACK_SZ    (COS_STACK_SZ / 4)
+
+#define ALL_STACK_SZ    (MAX_NUM_THREADS * MAX_STACK_SZ)
 #define MAX_SPD_VAS_LOCATIONS 8
 
 /* a kludge:  should not use a tmp stack on a stack miss */
 #define TMP_STACK_SZ       (128/4)
-#define ALL_TMP_STACKS_SZ  (MAX_NUM_THREADS*TMP_STACK_SZ)
+#define ALL_TMP_STACKS_SZ  (MAX_NUM_THREADS * TMP_STACK_SZ)
 
 #define MAX_SCHED_HIER_DEPTH 4
 


### PR DESCRIPTION
### Summary of this PR

Thread stack size is supposed to be determined by a constant in
consts.h. A lot of the code in the codebase relies on this,
including the code for fetching the a thread's id. However, the
assembly code that was really allocating the stack was using a
hardcoded value.

This mismatch led to invalid thread id's being returned, and
broke increasing stack sizes to avoid stack overflows.

To fix this, I made the assembly dependent on #defines, and made
sure those defines were available for those files. I also fixed
how those defines were structured in the first place.

### Code Quality

As part of this pull request, I've considered the following:

Style:

- [x] Comments adhere to the Style Guide (SG)
- [x] Spacing adhere's to the SG 
- [x] Naming adhere's to the SG
- [x] All other aspects of the SG are adhered to, or exceptions are justified in this pull request

Code Craftsmanship:

- [x] I've made an attempt to remove all redundant code
- [x] I've considered ways in which my changes might impact existing code, and cleaned it up
- [x] I've formatted the code in an effort to make it easier to read (proper error handling, function use, etc...)
- [x] I've commented appropriately where code is tricky
- [x] I agree that there is no "throw-away" code, and that code in this PR is of high quality
