### PR TITLE
Untrack auto-generated musl-gcc file for .gitignore to work

### DIFF
--- a/src/components/lib/musl-1.1.11/bin/musl-gcc
+++ b/src/components/lib/musl-1.1.11/bin/musl-gcc
@@ -1,2 +1,0 @@
-#!/bin/sh
-exec "${REALGCC:-gcc}" "$@" -specs "/home/gparmer/tmp/composite/src/components/lib/musl-1.1.11/lib/musl-gcc.specs"


### PR DESCRIPTION
### Summary of this PR

.gitignore doesn't work on tracked files, untracking musl-gcc file to make it work.

@Others fyi.

### Code Quality

As part of this pull request, I've considered the following:

Style:

- [x] Comments adhere to the Style Guide (SG)
- [x] Spacing adhere's to the SG 
- [x] Naming adhere's to the SG
- [x] All other aspects of the SG are adhered to, or exceptions are justified in this pull request

Code Craftsmanship:

- [x] I've made an attempt to remove all redundant code
- [x] I've considered ways in which my changes might impact existing code, and cleaned it up
- [x] I've formatted the code in an effort to make it easier to read (proper error handling, function use, etc...)
- [x] I've commented appropriately where code is tricky
- [x] I agree that there is no "throw-away" code, and that code in this PR is of high quality
