### PR TITLE
Critical-section in `sl_thd_alloc` and `sl_thd_free`

### DIFF
--- a/src/components/lib/sl/sl.c
+++ b/src/components/lib/sl/sl.c
@@ -374,6 +374,7 @@ sl_thd_free(struct sl_thd *t)
 	sl_thd_index_rem_backend(sl_mod_thd_policy_get(t));
 	sl_mod_thd_delete(sl_mod_thd_policy_get(t));
 	t->state = SL_THD_FREE;
+	/* TODO: add logic for the graveyard to delay this deallocation if t == current */
 	sl_thd_free_backend(sl_mod_thd_policy_get(t));
 
 	/* thread should not continue to run if it deletes itself. */

--- a/src/components/lib/sl/sl.c
+++ b/src/components/lib/sl/sl.c
@@ -339,20 +339,50 @@ done:
 
 struct sl_thd *
 sl_thd_alloc(cos_thd_fn_t fn, void *data)
-{ return sl_thd_alloc_intern(fn, data, NULL, 0); }
+{
+	struct sl_thd *t;
+
+	sl_cs_enter();
+	t = sl_thd_alloc_intern(fn, data, NULL, 0);
+	sl_cs_exit();
+
+	return t;
+}
 
 /* Allocate a thread that executes in the specified component */
 struct sl_thd *
 sl_thd_comp_alloc(struct cos_defcompinfo *comp)
-{ return sl_thd_alloc_intern(NULL, NULL, comp, 1); }
+{
+	struct sl_thd *t;
+
+	sl_cs_enter();
+	t = sl_thd_alloc_intern(NULL, NULL, comp, 1);
+	sl_cs_exit();
+
+	return t;
+}
 
 void
 sl_thd_free(struct sl_thd *t)
 {
+	struct sl_thd *ct = sl_thd_curr();
+
+	sl_cs_enter();
+
+	assert(t->state != SL_THD_FREE);
+	if (t->state == SL_THD_BLOCKED_TIMEOUT) sl_timeout_remove(t);
 	sl_thd_index_rem_backend(sl_mod_thd_policy_get(t));
+	sl_mod_thd_delete(sl_mod_thd_policy_get(t));
 	t->state = SL_THD_FREE;
-	/* TODO: add logic for the graveyard to delay this deallocation if t == current */
 	sl_thd_free_backend(sl_mod_thd_policy_get(t));
+
+	/* thread should not continue to run if it deletes itself. */
+	if (unlikely(t == ct)) {
+		sl_cs_exit_schedule();
+		/* should never get here */
+		assert(0);
+	}
+	sl_cs_exit();
 }
 
 void

--- a/src/components/lib/sl/sl_mod_fprr.c
+++ b/src/components/lib/sl/sl_mod_fprr.c
@@ -28,7 +28,6 @@ sl_mod_schedule(void)
 
 		return t;
 	}
-	assert(0);
 
 	return NULL;
 }


### PR DESCRIPTION
### Summary of this Pull Request (PR)

* cFE unit-tests have thread deallocation tests and found out that thread was being woken up from timeout-queue when it is being deleted and also more subtle issues on deleted threads. To avoid races, and to cleanup the thread (except the actual system resource) use critical-section and delete it from timeout queue and scheduling policy module. This is what @Others and I've debugged recently.
* It would be good if `sl_thd_alloc` is also atomic w.r.t sl library, so that there will not be races in backend allocations when users dynamically allocate more threads. Added that.
* removed assert when there is nothing to schedule from `sl_mod_schedule`.
* also added basic unit-tests for `sl_thd_free`. (idle thread runs after all test threads are deleted in the system.)

**Reference: PR #262**

### Intent for your PR

Choose one (Mandatory):

- [ ] This PR is for a code-review and is intended to get feedback, but not to be pulled yet.
- [x] This PR is mature, and ready to be integrated into the repo.

### Reviewers (Mandatory):
@gparmer @Others 

### Code Quality

As part of this pull request, I've considered the following:

[Style](https://github.com/gparmer/composite/raw/ppos/doc/style_guide/composite_coding_style.pdf):

- [x] Comments adhere to the Style Guide (SG)
- [x] Spacing adhere's to the SG
- [x] Naming adhere's to the SG
- [x] All other aspects of the SG are adhered to, or exceptions are justified in this pull request

[Code Craftsmanship](http://www2.seas.gwu.edu/~gparmer/posts/2016-03-07-code-craftsmanship.html):

- [x] I've made an attempt to remove all redundant code
- [x] I've considered ways in which my changes might impact existing code, and cleaned it up
- [x] I've formatted the code in an effort to make it easier to read (proper error handling, function use, etc...)
- [x] I've commented appropriately where code is tricky
- [x] I agree that there is no "throw-away" code, and that code in this PR is of high quality

### Testing

I've tested the code using the following test programs (provide list here):

- unit_schedtest with tests added for `sl_thd_free`.
