### PR TITLE
Bugfixes in sl, cos_kernel_api and kernel

### DIFF
--- a/src/components/include/sl.h
+++ b/src/components/include/sl.h
@@ -443,7 +443,8 @@ sl_cs_exit_schedule_nospin_arg(struct sl_thd *to)
 			if (currbudget < t->budget && cos_tcap_transfer(sl_thd_rcvcap(t), sl__globals()->sched_tcap, (t->budget - currbudget), t->prio)) assert(0);
 		}
 	}
-	assert(t->state == SL_THD_RUNNABLE);
+
+	assert(t->state == SL_THD_RUNNABLE || t->state == SL_THD_WOKEN);
 	sl_cs_exit();
 
 	/* TODO: handle `-EPERM` in cos_switch() to interrupt thread or cos_asnd to child comp with its own tcap here. */

--- a/src/components/lib/cos_kernel_api.c
+++ b/src/components/lib/cos_kernel_api.c
@@ -764,7 +764,7 @@ int
 cos_switch(thdcap_t c, tcap_t tc, tcap_prio_t prio, tcap_time_t timeout, arcvcap_t rcv, sched_tok_t stok)
 {
 	return call_cap_op(c, (stok >> 16), tc << 16 | rcv, (prio << 32) >> 32,
-	                   ((prio << 16) >> 32) | ((stok << 16) >> 16), timeout);
+	                   (((prio << 16) >> 48) << 16) | ((stok << 16) >> 16), timeout);
 }
 
 int

--- a/src/components/lib/sl/sl.c
+++ b/src/components/lib/sl/sl.c
@@ -141,18 +141,16 @@ sl_thd_block_no_cs(struct sl_thd *t, sl_thd_state_t block_type, cycles_t timeout
 	 */
 	if (unlikely(t->state == SL_THD_BLOCKED_TIMEOUT || t->state == SL_THD_BLOCKED)) {
 		if (t->state == SL_THD_BLOCKED_TIMEOUT) sl_timeout_remove(t);
-		if (block_type == SL_THD_BLOCKED_TIMEOUT) goto timeout;
-		else                                      goto done;
+		goto update;
 	}
 
 	assert(t->state == SL_THD_RUNNABLE);
-	t->state = block_type;
 	sl_mod_block(sl_mod_thd_policy_get(t));
 
-timeout:
-	sl_timeout_block(t, timeout);
+update:
+	t->state = block_type;
+	if (block_type == SL_THD_BLOCKED_TIMEOUT) sl_timeout_block(t, timeout);
 
-done:
 	return 0;
 }
 

--- a/src/kernel/capinv.c
+++ b/src/kernel/capinv.c
@@ -735,7 +735,8 @@ cap_asnd_op(struct cap_asnd *asnd, struct thread *thd, struct pt_regs *regs, str
 
 			next = rcvt;
 			/* tcap inheritance here...use the current tcap to process events */
-			timeout = TCAP_TIME_NIL;
+			tcap_next = tcap;
+			timeout   = TCAP_TIME_NIL;
 			goto done;
 		}
 


### PR DESCRIPTION
### Summary of this Pull Request (PR)

* sl: 
       1. sl_thd_block was broken because it was trying to set a timeout for a non-timeout block.
       2. sl_cs_exit_schedule_nospin_arg should be able to schedule a thread that is in SL_THD_WOKEN state. 
* kernel: tcap_next should be set to current tcap for switching to scheduler in `cos_sched_asnd` case.
* cos_kernel_api: cos_switch bit packing fix: packing higher order 16bits from 48bit tcap_prio_t into higher order 16bits of arg3 to call_cap_op.

### Intent for your PR

Choose one (Mandatory):

- [ ] This PR is for a code-review and is intended to get feedback, but not to be pulled yet.
- [x] This PR is mature, and ready to be integrated into the repo.

### Reviewers (Mandatory):
@gparmer 

### Code Quality

As part of this pull request, I've considered the following:

[Style](https://github.com/gparmer/composite/raw/ppos/doc/style_guide/composite_coding_style.pdf):

- [x] Comments adhere to the Style Guide (SG)
- [x] Spacing adhere's to the SG
- [x] Naming adhere's to the SG
- [x] All other aspects of the SG are adhered to, or exceptions are justified in this pull request
- [ ] I have run the auto formatter on my code before submitting this PR (see doc/auto_formatter.md for instructions)

[Code Craftsmanship](http://www2.seas.gwu.edu/~gparmer/posts/2016-03-07-code-craftsmanship.html):

- [x] I've made an attempt to remove all redundant code
- [x] I've considered ways in which my changes might impact existing code, and cleaned it up
- [x] I've formatted the code in an effort to make it easier to read (proper error handling, function use, etc...)
- [x] I've commented appropriately where code is tricky
- [x] I agree that there is no "throw-away" code, and that code in this PR is of high quality

### Testing

I've tested the code using the following test programs (provide list here):

- vkernel, micro booter, unit_schedtests, unit_defci, unit_cxx, llbooter_test
