### PR TITLE
Switch to scheduler thread on timer (timeout) interrupts

### DIFF
--- a/src/components/include/sl.h
+++ b/src/components/include/sl.h
@@ -238,6 +238,8 @@ int          sl_thd_block_no_cs(struct sl_thd *t, sl_thd_state_t block_type, cyc
 /* wakeup a thread that has (or soon will) block */
 void sl_thd_wakeup(thdid_t tid);
 int  sl_thd_wakeup_no_cs(struct sl_thd *t);
+/* wakeup thread and do not remove from timeout queue if blocked on timeout */
+int  sl_thd_wakeup_no_cs_rm(struct sl_thd *t);
 
 void sl_thd_yield(thdid_t tid);
 void sl_thd_yield_cs_exit(thdid_t tid);
@@ -347,7 +349,7 @@ sl_timeout_wakeup_expired(cycles_t now)
 
 		assert(th->wakeup_cycs == 0);
 		th->wakeup_cycs = now;
-		sl_thd_wakeup_no_cs(th);
+		sl_thd_wakeup_no_cs_rm(th);
 	} while (heap_size(sl_timeout_heap()));
 }
 

--- a/src/components/lib/sl/sl.c
+++ b/src/components/lib/sl/sl.c
@@ -243,7 +243,7 @@ done:
  *          0 if it was woken up in this call
  */
 int
-sl_thd_wakeup_no_cs(struct sl_thd *t)
+sl_thd_wakeup_no_cs_rm(struct sl_thd *t)
 {
 	assert(t);
 
@@ -260,6 +260,15 @@ sl_thd_wakeup_no_cs(struct sl_thd *t)
 	return 0;
 }
 
+int
+sl_thd_wakeup_no_cs(struct sl_thd *t)
+{
+	assert(t);
+
+	if (t->state == SL_THD_BLOCKED_TIMEOUT) sl_timeout_remove(t);
+	return sl_thd_wakeup_no_cs_rm(t);
+}
+
 void
 sl_thd_wakeup(thdid_t tid)
 {
@@ -271,7 +280,6 @@ sl_thd_wakeup(thdid_t tid)
 	t = sl_thd_lkup(tid);
 	if (unlikely(!t)) goto done;
 
-	if (t->state == SL_THD_BLOCKED_TIMEOUT) sl_timeout_remove(t);
 	if (sl_thd_wakeup_no_cs(t)) goto done;
 	sl_cs_exit_schedule();
 

--- a/src/kernel/include/inv.h
+++ b/src/kernel/include/inv.h
@@ -154,6 +154,7 @@ __arcv_setup(struct cap_arcv *arcv, struct thread *thd, struct tcap *tcap, struc
 	assert(arcv && thd && tcap && !thd_bound2rcvcap(thd));
 	arcv->thd                    = thd;
 	thd->rcvcap.rcvcap_thd_notif = notif;
+	thd_scheduler_set(thd, notif);
 	if (notif) thd_rcvcap_take(notif);
 	thd->rcvcap.isbound = 1;
 

--- a/src/platform/i386/boot_comp.c
+++ b/src/platform/i386/boot_comp.c
@@ -114,6 +114,7 @@ kern_boot_thd(struct captbl *ct, void *thd_mem, void *tcap_mem)
 	thd_next_thdinfo_update(cos_info, 0, 0, 0, 0);
 
 	thd_current_update(t, t, cos_info);
+	thd_scheduler_set(t, t);
 
 	ret = arcv_activate(ct, BOOT_CAPTBL_SELF_CT, BOOT_CAPTBL_SELF_INITRCV_BASE, BOOT_CAPTBL_SELF_COMP,
 	                    BOOT_CAPTBL_SELF_INITTHD_BASE, BOOT_CAPTBL_SELF_INITTCAP_BASE, 0, 1);

--- a/src/platform/i386/kernel.c
+++ b/src/platform/i386/kernel.c
@@ -140,10 +140,6 @@ kmain(struct multiboot *mboot, u32_t mboot_magic, u32_t esp)
 #ifdef ENABLE_CONSOLE
 	console_init();
 #endif
-#ifdef ENABLE_VGA
-	vga_init();
-#endif
-
 	max = MAX((unsigned long)mboot->mods_addr,
 	          MAX((unsigned long)mboot->mmap_addr, (unsigned long)(chal_va2pa(&end))));
 	kern_paging_map_init((void *)(max + PGD_SIZE));
@@ -157,9 +153,9 @@ kmain(struct multiboot *mboot, u32_t mboot_magic, u32_t esp)
 	thd_init();
 	paging_init();
 #ifdef ENABLE_VGA
-	vga_high_init();
+	/* uses virtual address for VGA. should be after paging_init() */
+	vga_init();
 #endif
-
 	kern_boot_comp();
 	smp_init();
 	timer_init();

--- a/src/platform/i386/kernel.h
+++ b/src/platform/i386/kernel.h
@@ -18,7 +18,6 @@ void console_init(void);
 
 #ifdef ENABLE_VGA
 void vga_init(void);
-void vga_high_init(void);
 void vga_puts(const char *str);
 #endif
 

--- a/src/platform/i386/vga.c
+++ b/src/platform/i386/vga.c
@@ -160,25 +160,21 @@ cls(void)
 	move_csr();
 }
 
-/* Clear the screen and initialize VIDEO, XPOS and YPOS. */
+/*
+ * Clear the screen and initialize VIDEO, XPOS and YPOS.
+ * VIDEO virtual address set to HIGH address.
+ */
 void
 vga_init(void)
 {
 	int i = 0;
 
-	video = (unsigned char *)VIDEO;
+	video = chal_pa2va(VIDEO);
 
 	csr_x = 0;
 	csr_y = 0;
 	cls();
 	printk_register_handler(vga_puts);
-}
-
-/* Initialize VIDEO virtual address - High address. */
-void
-vga_high_init(void)
-{
-	video = chal_pa2va(VIDEO);
 }
 
 /* Put the character C on the screen. */


### PR DESCRIPTION
### Summary of this Pull Request (PR)

Major:
* Support for switching to scheduler thread of the current thread on timeout expiry. Scheduler thread is the thread associated with scheduler recv endpoint on `cos_switch` or `cos_sched_asnd`. 

Minor:
* VGA: It looks like the bare metal boot faults at random places with new ACPI/APIC changes and I could relate that to VGA driver, but haven't thoroughly debugged it. For now, allowing VGA printks only after `paging_init`. This is a workaround for now, need to debug the actual issue after the deadline.
* Yet another bug in SL: `sl_thd_wakeup_no_cs_rm` API to not use CS or not remove thread from the timeout queue, this is required by `sl_timeout_xxx` api. `sl_thd_wakeup_no_cs` however is a wrapper around this with removal from timeout queue if thread was blocked on timeout. 

### Intent for your PR

Choose one (Mandatory):

- [ ] This PR is for a code-review and is intended to get feedback, but not to be pulled yet.
- [x] This PR is mature, and ready to be integrated into the repo.

### Reviewers (Mandatory):
@gparmer 


### Code Quality

As part of this pull request, I've considered the following:

[Style](https://github.com/gparmer/composite/raw/ppos/doc/style_guide/composite_coding_style.pdf):

- [x] Comments adhere to the Style Guide (SG)
- [x] Spacing adhere's to the SG
- [x] Naming adhere's to the SG
- [x] All other aspects of the SG are adhered to, or exceptions are justified in this pull request
- [ ] I have run the auto formatter on my code before submitting this PR (see doc/auto_formatter.md for instructions)

[Code Craftsmanship](http://www2.seas.gwu.edu/~gparmer/posts/2016-03-07-code-craftsmanship.html):

- [x] I've made an attempt to remove all redundant code
- [x] I've considered ways in which my changes might impact existing code, and cleaned it up
- [x] I've formatted the code in an effort to make it easier to read (proper error handling, function use, etc...)
- [x] I've commented appropriately where code is tricky
- [x] I agree that there is no "throw-away" code, and that code in this PR is of high quality

### Testing

I've tested the code using the following test programs (provide list here):

- unit tests in `implementation/tests`
- vkernel in `implementation/no_interface`
- integrated in rump2cos env and basic tests with ping works fine. [There is one major problem which is not related to this PR but perhaps to using sl as vkernel scheduling, and I'm working on that problem -- at some point, system stops responding to pings. ]
